### PR TITLE
Fix tag workflow suffix

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,4 +20,3 @@ jobs:
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^\\s*gradle.ext.releaseVersion\\s*=\\s*'.*'"
-          VERSION_SUFFIX: SNAPSHOT

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,4 +20,4 @@ jobs:
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: settings.gradle
           VERSION_LINE_MATCH: "^\\s*gradle.ext.releaseVersion\\s*=\\s*'.*'"
-          VERSION_SUFFIX: -SNAPSHOT
+          VERSION_SUFFIX: SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name = 'terra-data-catalog'
 include('service', 'client', 'integration')
 
-gradle.ext.releaseVersion = '0.0.2--SNAPSHOT'
+gradle.ext.releaseVersion = '0.0.2-SNAPSHOT'


### PR DESCRIPTION
~The tag operation adds a `-` to the suffix so the GitHub action input doesn't need to have it.~

The `SNAPSHOT` suffix isn't necessary after all, see comment below.