### PR TITLE
DC-229: Fix recursive workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,9 +1,6 @@
 name: Build and Test
 
 on:
-  push:
-    branches: [ main ]
-    paths-ignore: [ '*.md' ]
   pull_request:
     branches: [ '**' ]
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Notify slack on failure
         uses: broadinstitute/action-slack@v3.8.0
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CATALOG_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           channel: '#jade-data-explorer'
           status: failure


### PR DESCRIPTION
When this action runs on push to main and succeeds, it will launch the tag bumping action. The tag bumping action will push a new version to main, causing this workflow to run again recursively.