### PR TITLE
DC-229: Fix Artifactory gradle

### DIFF
--- a/client/artifactory.gradle
+++ b/client/artifactory.gradle
@@ -2,6 +2,7 @@
 // to publish without the environment variables defined.
 def artifactory_username = System.getenv("ARTIFACTORY_USERNAME")
 def artifactory_password = System.getenv("ARTIFACTORY_PASSWORD")
+def artifactory_repo_key = System.getenv("ARTIFACTORY_REPO_KEY")
 
 gradle.taskGraph.whenReady { taskGraph ->
     if (taskGraph.hasTask(artifactoryPublish) &&
@@ -33,7 +34,7 @@ artifactory {
     publish {
         contextUrl = "https://broadinstitute.jfrog.io/broadinstitute/"
         repository {
-            repoKey = "libs-snapshot-local" // The Artifactory repository key to publish to
+            repoKey  = "${artifactory_repo_key}" // The Artifactory repository key to publish to
             username = "${artifactory_username}" // The publisher user name
             password = "${artifactory_password}" // The publisher password
         }


### PR DESCRIPTION
Add the environment variable to the Artifactory gradle to ensure we can override the repo key.