### PR TITLE
DC-251: Add source clear and sonarqube scanners to build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -120,14 +120,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+          cache: 'gradle'
 
       - name: SonarQube scan
         run: ./gradlew --build-cache -Dsonar.login="${{ secrets.SONAR_TOKEN }}" sonarqube

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -151,7 +151,7 @@ jobs:
           key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
 
       - name: SonarQube scan
-        run: ./gradlew -Dsonar.login="${{ secrets.SONAR_TOKEN }}" --build-cache sonarqube
+        run: ./gradlew --build-cache -Dsonar.login="${{ secrets.SONAR_TOKEN }}" sonarqube
 
   integration-tests:
     needs: [ build ]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -112,6 +112,54 @@ jobs:
         with:
           files: ./service/build/reports/jacoco/test/jacocoTestReport.xml
 
+  source-clear:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+      - name: SourceClear scan
+        env:
+          SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
+        run: ./gradlew --build-cache :service:srcclr
+
+  sonar-scanner:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+
+      - name: SonarQube scan
+        run: ./gradlew -Dsonar.login="${{ secrets.SONAR_TOKEN }}" --build-cache :service:sonarqube
+
   integration-tests:
     needs: [ build ]
     runs-on: ubuntu-latest
@@ -171,7 +219,7 @@ jobs:
         run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
 
   notify-slack:
-    needs: [ build, jib, unit-tests, integration-tests ]
+    needs: [ build, jib, unit-tests, source-clear, integration-tests ]
     runs-on: ubuntu-latest
 
     if: failure() && github.ref == 'refs/heads/main'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -135,7 +135,7 @@ jobs:
       - name: SourceClear scan
         env:
           SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
-        run: ./gradlew --build-cache :service:srcclr
+        run: ./gradlew --build-cache srcclr
 
   sonar-scanner:
     needs: [ build ]
@@ -158,7 +158,7 @@ jobs:
           key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
 
       - name: SonarQube scan
-        run: ./gradlew -Dsonar.login="${{ secrets.SONAR_TOKEN }}" --build-cache :service:sonarqube
+        run: ./gradlew -Dsonar.login="${{ secrets.SONAR_TOKEN }}" --build-cache sonarqube
 
   integration-tests:
     needs: [ build ]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -123,14 +123,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-
-      - name: Gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: v1-${{ runner.os }}-gradle-${{ github.ref }}-${{ github.sha }}
+          cache: 'gradle'
 
       - name: SourceClear scan
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -219,7 +219,7 @@ jobs:
         run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
 
   notify-slack:
-    needs: [ build, jib, unit-tests, source-clear, integration-tests ]
+    needs: [ build, jib, unit-tests, source-clear, sonar-scanner, integration-tests ]
     runs-on: ubuntu-latest
 
     if: failure() && github.ref == 'refs/heads/main'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,6 +12,7 @@ repositories {
 dependencies {
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.3.0'
     implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.2.0'
+    implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.10'
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.0.1'
     implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.2'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.10.RELEASE'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -20,4 +20,6 @@ dependencies {
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:3.3'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:2.6.3'
     implementation 'bio.terra:terra-test-runner:0.0.8-SNAPSHOT'
+    // This is required due to a dependency conflict between jib and srcclr. Removing it will cause jib to fail.
+    implementation 'org.apache.commons:commons-compress:1.21'
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,7 +12,7 @@ repositories {
 dependencies {
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.3.0'
     implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.2.0'
-    implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.10'
+//    implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.10'
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.0.1'
     implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.2'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.10.RELEASE'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,7 +12,6 @@ repositories {
 dependencies {
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.3.0'
     implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.2.0'
-//    implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.10'
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.0.1'
     implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.2'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.10.RELEASE'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.2.0'
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.0.1'
     implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.2'
+    implementation 'gradle.plugin.com.srcclr:gradle:3.1.10'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.10.RELEASE'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.1'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:2.6.3'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,11 +12,12 @@ repositories {
 dependencies {
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.3.0'
     implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.2.0'
+    implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.10'
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.0.1'
     implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.2'
-    implementation 'gradle.plugin.com.srcclr:gradle:3.1.10'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.10.RELEASE'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.1'
+    implementation 'org.sonarqube:org.sonarqube.gradle.plugin:3.3'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:2.6.3'
     implementation 'bio.terra:terra-test-runner:0.0.8-SNAPSHOT'
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -16,3 +16,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.retry:spring-retry'
 }
+plugins {
+    id "org.sonarqube" version "3.3"
+}
+
+sonarqube {
+    properties {
+        property "sonar.projectKey", "terra-data-catalog"
+        property "sonar.organization", "broad-databiosphere"
+        property "sonar.host.url", "https://sonarcloud.io"
+    }
+}

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'com.google.cloud.tools.jib'
 
     id 'com.gorylenko.gradle-git-properties' version '2.3.1'
+    id 'org.sonarqube'
+    id 'com.srcclr.gradle'
 }
 
 apply from: 'generators.gradle'
@@ -15,9 +17,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.retry:spring-retry'
-}
-plugins {
-    id "org.sonarqube" version "3.3"
 }
 
 sonarqube {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -31,8 +31,8 @@ test {
 
 sonarqube {
     properties {
-        property "sonar.projectKey", "terra-data-catalog"
-        property "sonar.organization", "broad-databiosphere"
-        property "sonar.host.url", "https://sonarcloud.io"
+        property 'sonar.projectKey', 'terra-data-catalog'
+        property 'sonar.organization', 'broad-databiosphere'
+        property 'sonar.host.url', 'https://sonarcloud.io'
     }
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -2,9 +2,9 @@ plugins {
     id 'bio.terra.catalog.java-spring-conventions'
     id 'de.undercouch.download'
     id 'com.google.cloud.tools.jib'
+    id 'org.sonarqube'
 
     id 'com.gorylenko.gradle-git-properties' version '2.3.1'
-    id 'org.sonarqube'
     id 'com.srcclr.gradle' version '3.1.10'
 }
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
     id 'com.gorylenko.gradle-git-properties' version '2.3.1'
     id 'org.sonarqube'
-    id 'com.srcclr.gradle'
+    id 'com.srcclr.gradle' version '3.1.10'
 }
 
 apply from: 'generators.gradle'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -2,10 +2,10 @@ plugins {
     id 'bio.terra.catalog.java-spring-conventions'
     id 'de.undercouch.download'
     id 'com.google.cloud.tools.jib'
+    id 'com.srcclr.gradle'
     id 'org.sonarqube'
 
     id 'com.gorylenko.gradle-git-properties' version '2.3.1'
-    id 'com.srcclr.gradle' version '3.1.10'
 }
 
 apply from: 'generators.gradle'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name = 'terra-data-catalog'
 include('service', 'client', 'integration')
 
-gradle.ext.releaseVersion = '0.8.0'
+gradle.ext.releaseVersion = '0.9.0'


### PR DESCRIPTION
This adds source clear and sonarqube scans to our PR tests. Source clear checks for vulnerabilities in .jars that we depend on, and sonarqube runs a number of static code analysis checks on our Java code.

~Note that builds will fail until the GitHub secrets are published once https://github.com/broadinstitute/terraform-ap-deployments/pull/551 is merged.~

