### PR TITLE
DC-233: update to use testrunner field

### DIFF
--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.4.0'
 
     // Terra Test Runner Library
-    implementation 'bio.terra:terra-test-runner:0.0.10-SNAPSHOT'
+    implementation 'bio.terra:terra-test-runner:0.1.1-SNAPSHOT'
 
     // Requires client library
     implementation project(':client')

--- a/integration/src/main/java/scripts/client/CatalogClient.java
+++ b/integration/src/main/java/scripts/client/CatalogClient.java
@@ -1,4 +1,4 @@
-package scripts.utils;
+package scripts.client;
 
 import bio.terra.catalog.client.ApiClient;
 import bio.terra.testrunner.common.utils.AuthenticationUtils;

--- a/integration/src/main/java/scripts/client/CatalogClient.java
+++ b/integration/src/main/java/scripts/client/CatalogClient.java
@@ -33,8 +33,8 @@ public class CatalogClient extends ApiClient {
    * @param server the server we are testing against
    * @param testUser the test user whose credentials are supplied to the API client object
    */
-  public CatalogClient(
-      ServerSpecification server, TestUserSpecification testUser) throws IOException {
+  public CatalogClient(ServerSpecification server, TestUserSpecification testUser)
+      throws IOException {
     setBasePath(Objects.requireNonNull(server.catalogUri, "Catalog URI required"));
 
     if (testUser != null) {

--- a/integration/src/main/java/scripts/testscripts/GetStatus.java
+++ b/integration/src/main/java/scripts/testscripts/GetStatus.java
@@ -8,7 +8,7 @@ import bio.terra.testrunner.runner.config.TestUserSpecification;
 import com.google.api.client.http.HttpStatusCodes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import scripts.utils.ClientTestUtils;
+import scripts.utils.CatalogClient;
 
 public class GetStatus extends TestScript {
 
@@ -17,8 +17,7 @@ public class GetStatus extends TestScript {
   @Override
   public void userJourney(TestUserSpecification testUser) throws Exception {
     log.info("Checking the service status endpoint.");
-    var apiClient = ClientTestUtils.getClientWithoutAuth(server);
-    var publicApi = new PublicApi(apiClient);
+    var publicApi = new PublicApi(new CatalogClient(server));
     publicApi.getStatus();
     var httpCode = publicApi.getApiClient().getStatusCode();
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, httpCode);

--- a/integration/src/main/java/scripts/testscripts/GetStatus.java
+++ b/integration/src/main/java/scripts/testscripts/GetStatus.java
@@ -8,7 +8,7 @@ import bio.terra.testrunner.runner.config.TestUserSpecification;
 import com.google.api.client.http.HttpStatusCodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scripts.utils.CatalogClient;
+import scripts.client.CatalogClient;
 
 public class GetStatus extends TestScript {
 

--- a/integration/src/main/java/scripts/testscripts/GetVersion.java
+++ b/integration/src/main/java/scripts/testscripts/GetVersion.java
@@ -9,7 +9,7 @@ import bio.terra.testrunner.runner.config.TestUserSpecification;
 import com.google.api.client.http.HttpStatusCodes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import scripts.utils.ClientTestUtils;
+import scripts.utils.CatalogClient;
 
 public class GetVersion extends TestScript {
 
@@ -18,8 +18,7 @@ public class GetVersion extends TestScript {
   @Override
   public void userJourney(TestUserSpecification testUser) throws Exception {
     log.info("Checking the version endpoint.");
-    var apiClient = ClientTestUtils.getClientWithoutAuth(server);
-    var publicApi = new PublicApi(apiClient);
+    var publicApi = new PublicApi(new CatalogClient(server));
 
     var versionProperties = publicApi.getVersion();
 

--- a/integration/src/main/java/scripts/testscripts/GetVersion.java
+++ b/integration/src/main/java/scripts/testscripts/GetVersion.java
@@ -9,7 +9,7 @@ import bio.terra.testrunner.runner.config.TestUserSpecification;
 import com.google.api.client.http.HttpStatusCodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scripts.utils.CatalogClient;
+import scripts.client.CatalogClient;
 
 public class GetVersion extends TestScript {
 

--- a/integration/src/main/java/scripts/testscripts/ListDatasets.java
+++ b/integration/src/main/java/scripts/testscripts/ListDatasets.java
@@ -10,7 +10,7 @@ import com.google.api.client.http.HttpStatusCodes;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scripts.utils.ClientTestUtils;
+import scripts.client.CatalogClient;
 
 public class ListDatasets extends TestScript {
 
@@ -19,8 +19,7 @@ public class ListDatasets extends TestScript {
   @Override
   public void userJourney(TestUserSpecification testUser) throws Exception {
     log.info("Checking the list datasets endpoint.");
-    var apiClient = ClientTestUtils.getClientWithTestUserAuth(testUser, server);
-    var publicApi = new DatasetApi(apiClient);
+    var publicApi = new DatasetApi(new CatalogClient(server, testUser));
     List<String> datasets = publicApi.listDatasets();
     var httpCode = publicApi.getApiClient().getStatusCode();
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, httpCode);

--- a/integration/src/main/java/scripts/utils/CatalogClient.java
+++ b/integration/src/main/java/scripts/utils/CatalogClient.java
@@ -5,13 +5,11 @@ import bio.terra.testrunner.common.utils.AuthenticationUtils;
 import bio.terra.testrunner.runner.config.ServerSpecification;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.common.base.Strings;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
-public class ClientTestUtils {
-
-  private ClientTestUtils() {}
+public class CatalogClient extends ApiClient {
 
   // Required scopes for client tests include the usual login scopes and GCP scope.
   public static final List<String> TEST_USER_SCOPES =
@@ -22,16 +20,9 @@ public class ClientTestUtils {
    * API client.
    *
    * @param server the server we are testing against
-   * @return the API client object for this user
    */
-  public static ApiClient getClientWithoutAuth(ServerSpecification server) {
-    if (Strings.isNullOrEmpty(server.policyManagerUri)) {
-      throw new IllegalArgumentException("Service URI cannot be empty");
-    }
-
-    var apiClient = new ApiClient();
-    apiClient.setBasePath(server.policyManagerUri);
-    return apiClient;
+  public CatalogClient(ServerSpecification server) throws IOException {
+    this(server, null);
   }
 
   /**
@@ -39,22 +30,20 @@ public class ClientTestUtils {
    * is always refreshed. If a test user isn't configured (e.g. when running locally), return an
    * un-authenticated client.
    *
-   * @param testUser the test user whose credentials are supplied to the API client object
    * @param server the server we are testing against
+   * @param testUser the test user whose credentials are supplied to the API client object
    */
-  public static ApiClient getClientWithTestUserAuth(
-      TestUserSpecification testUser, ServerSpecification server) throws IOException {
-    var apiClient = getClientWithoutAuth(server);
+  public CatalogClient(
+      ServerSpecification server, TestUserSpecification testUser) throws IOException {
+    setBasePath(Objects.requireNonNull(server.catalogUri, "Catalog URI required"));
 
     if (testUser != null) {
       GoogleCredentials userCredential =
           AuthenticationUtils.getDelegatedUserCredential(testUser, TEST_USER_SCOPES);
       var accessToken = AuthenticationUtils.getAccessToken(userCredential);
       if (accessToken != null) {
-        apiClient.setAccessToken(accessToken.getTokenValue());
+        setAccessToken(accessToken.getTokenValue());
       }
     }
-
-    return apiClient;
   }
 }

--- a/integration/src/main/resources/servers/catalog-local.json
+++ b/integration/src/main/resources/servers/catalog-local.json
@@ -3,7 +3,7 @@
   "description": "Catalog Local env.",
 
   "samUri": "https://sam.dsde-dev.broadinstitute.org",
-  "policyManagerUri": "http://localhost:8080",
+  "catalogUri": "http://localhost:8080",
 
   "testRunnerServiceAccountFile": "delegate-user-sa.json",
 

--- a/integration/src/main/resources/servers/catalog-perf.json
+++ b/integration/src/main/resources/servers/catalog-perf.json
@@ -3,7 +3,7 @@
   "description": "Catalog Performance Testing Environment",
 
   "samUri": "https://sam.dsde-perf.broadinstitute.org",
-  "policyManagerUri": "https://catalog.dsde-perf.broadinstitute.org/",
+  "catalogUri": "https://catalog.dsde-perf.broadinstitute.org/",
 
   "cluster": {
     "clusterName": "terra-perf",


### PR DESCRIPTION
Now that testrunner has a server config for catalog, use it instead of policy manager.