### PR TITLE
DC-253: Run unit tests on PRs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,7 +128,7 @@ jobs:
           cache: 'gradle'
 
       - name: SonarQube scan
-        run: ./gradlew --build-cache -Dsonar.login="${{ secrets.SONAR_TOKEN }}" sonarqube --info
+        run: ./gradlew --build-cache -Dsonar.login="${{ secrets.SONAR_TOKEN }}" test jacocoTestReport sonarqube --info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -191,7 +191,7 @@ jobs:
         run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
 
   notify-slack:
-    needs: [ build, jib, unit-tests, source-clear, sonar-scanner, integration-tests ]
+    needs: [ build, jib, unit-tests, source-clear, integration-tests ]
     runs-on: ubuntu-latest
 
     if: failure() && github.ref == 'refs/heads/main'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -180,7 +180,7 @@ jobs:
         run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
 
   notify-slack:
-    needs: [ build, jib, sonar-scanner, source-clear, integration-tests ]
+    needs: [ build, jib, source-clear, sonar-scanner, integration-tests ]
     runs-on: ubuntu-latest
 
     if: failure() && github.ref == 'refs/heads/main'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -119,25 +119,25 @@ jobs:
           SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
         run: ./gradlew --build-cache srcclr
 
-#  sonar-scanner:
-#    needs: [ unit-tests ]
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      - uses: actions/checkout@v2
-#        with:
-#          fetch-depth: 0
-#      - name: Set up JDK
-#        uses: actions/setup-java@v2
-#        with:
-#          java-version: '17'
-#          distribution: 'temurin'
-#          cache: 'gradle'
-#
-#      - name: SonarQube scan
-#        run: ./gradlew --build-cache -Dsonar.login="${{ secrets.SONAR_TOKEN }}" test jacocoTestReport sonarqube --info
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  sonar-scanner:
+    needs: [ unit-tests ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: SonarQube scan
+        run: ./gradlew --build-cache -Dsonar.login="${{ secrets.SONAR_TOKEN }}" sonarqube
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   integration-tests:
     needs: [ build ]
@@ -191,7 +191,7 @@ jobs:
         run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
 
   notify-slack:
-    needs: [ build, jib, unit-tests, source-clear, integration-tests ]
+    needs: [ build, jib, sonar-scanner, source-clear, integration-tests ]
     runs-on: ubuntu-latest
 
     if: failure() && github.ref == 'refs/heads/main'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,6 +83,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        # Needed by sonar to get the git history for the branch the PR will be merged into.
         with:
           fetch-depth: 0
       - name: Set up JDK

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -111,8 +111,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
@@ -128,12 +126,7 @@ jobs:
           psql -h localhost -U postgres -f ./common/postgres-init.sql
 
       - name: Test with coverage
-        run: ./gradlew --build-cache jacocoTestReport
-
-      - name: Codecov
-        uses: codecov/codecov-action@v2.0.2
-        with:
-          files: ./service/build/reports/jacoco/test/html/index.html
+        run: ./gradlew --build-cache test jacocoTestReport
 
   integration-tests:
     needs: [ build ]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -118,6 +118,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,7 +128,7 @@ jobs:
           cache: 'gradle'
 
       - name: SonarQube scan
-        run: ./gradlew --build-cache -Dsonar.login="${{ secrets.SONAR_TOKEN }}" sonarqube
+        run: ./gradlew --build-cache -Dsonar.login="${{ secrets.SONAR_TOKEN }}" sonarqube --info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -181,7 +181,7 @@ jobs:
         run: ./gradlew --build-cache :integration:runTest --args="suites/FullIntegration.json /tmp/foo"
 
   notify-slack:
-    needs: [ build, jib, source-clear, sonar-scanner, integration-tests ]
+    needs: [ build, jib, unit-tests, source-clear, sonar-scanner, integration-tests ]
     runs-on: ubuntu-latest
 
     if: failure() && github.ref == 'refs/heads/main'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -72,6 +72,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
@@ -94,6 +96,11 @@ jobs:
         with:
           files: ./service/build/reports/jacoco/test/html/index.html
 
+      - name: SonarQube scan
+        run: ./gradlew --build-cache -Dsonar.login="${{ secrets.SONAR_TOKEN }}" sonarqube --info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   source-clear:
     needs: [ build ]
     runs-on: ubuntu-latest
@@ -112,25 +119,25 @@ jobs:
           SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
         run: ./gradlew --build-cache srcclr
 
-  sonar-scanner:
-    needs: [ unit-tests ]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
-
-      - name: SonarQube scan
-        run: ./gradlew --build-cache -Dsonar.login="${{ secrets.SONAR_TOKEN }}" test jacocoTestReport sonarqube --info
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#  sonar-scanner:
+#    needs: [ unit-tests ]
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - uses: actions/checkout@v2
+#        with:
+#          fetch-depth: 0
+#      - name: Set up JDK
+#        uses: actions/setup-java@v2
+#        with:
+#          java-version: '17'
+#          distribution: 'temurin'
+#          cache: 'gradle'
+#
+#      - name: SonarQube scan
+#        run: ./gradlew --build-cache -Dsonar.login="${{ secrets.SONAR_TOKEN }}" test jacocoTestReport sonarqube --info
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   integration-tests:
     needs: [ build ]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,7 +87,7 @@ jobs:
           psql -h localhost -U postgres -f ./common/postgres-init.sql
 
       - name: Test with coverage
-        run: ./gradlew --build-cache jacocoTestReport
+        run: ./gradlew --build-cache test jacocoTestReport
 
       - name: Codecov
         uses: codecov/codecov-action@v2.0.2
@@ -113,7 +113,7 @@ jobs:
         run: ./gradlew --build-cache srcclr
 
   sonar-scanner:
-    needs: [ build ]
+    needs: [ unit-tests ]
     runs-on: ubuntu-latest
 
     steps:

--- a/buildSrc/src/main/groovy/bio.terra.catalog.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.catalog.java-common-conventions.gradle
@@ -88,6 +88,7 @@ spotbugsMain {
 
 jacocoTestReport {
     reports {
+        // sonarqube requires XML coverage output to upload coverage data
         xml.required = true
     }
 }

--- a/buildSrc/src/main/groovy/bio.terra.catalog.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.catalog.java-common-conventions.gradle
@@ -85,3 +85,9 @@ spotbugsMain {
         }
     }
 }
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+    }
+}


### PR DESCRIPTION
Add the `test` task to the jacoco gradle target so unit tests are run.

- generate an XML jacoco report for sonarqube
- run unit-tests before sonarqube so XML report is present (not working yet)
- use fetch-depth to checkout target merge branch for sonarqube

The ticket https://broadworkbench.atlassian.net/browse/DC-262 tracks the remaining work to upload coverage data using sonarqube.