### PR TITLE
DC-251: Change back to distroless base image

### DIFF
--- a/service/publishing.gradle
+++ b/service/publishing.gradle
@@ -1,3 +1,4 @@
+import java.time.ZonedDateTime
 
 // Download and extract the Cloud Profiler Java Agent
 ext {
@@ -20,13 +21,13 @@ task extractProfilerAgent(dependsOn: downloadProfilerAgent, type: Copy) {
 jib {
     from {
         // see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre
-        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian"
+        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-distroless"
     }
     extraDirectories {
         paths = [file(jibExtraDirectory)]
     }
     container {
-        filesModificationTime = java.time.ZonedDateTime.now().toString() // to prevent ui caching
+        filesModificationTime = ZonedDateTime.now().toString() // to prevent ui caching
         mainClass = 'bio.terra.catalog.app.App'
         jvmFlags = [
             "-agentpath:" + cloudProfilerLocation + "/profiler_java_agent.so=" +


### PR DESCRIPTION
This reverts an earlier change where distroless was failing trivy so we switched to the debian base image.