### PR TITLE
DC-195: create/read/update/delete dataset metadata

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.catalog.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.catalog.java-common-conventions.gradle
@@ -14,6 +14,9 @@ if (!isCiServer) {
     tasks.withType(JavaExec).configureEach {
         systemProperty 'spring.profiles.include', 'human-readable-logging'
     }
+    tasks.withType(Test).configureEach {
+        systemProperty 'spring.profiles.include', 'human-readable-logging'
+    }
 }
 
 java {

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -61,9 +61,8 @@ paths:
               $ref: '#/components/schemas/CreateDatasetRequest'
         required: true
       responses:
-        204:
-          description: The catalog entry was created successfully
-          content: { }
+        200:
+          $ref: '#/components/responses/DatasetResponse'
         403:
           description: No permission to modify metadata
           content:
@@ -158,6 +157,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/SystemStatus'
+    DatasetResponse:
+      description: The created dataset's ID
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreatedDatasetId'
 
     # Error Responses
     BadRequest:
@@ -213,6 +218,14 @@ components:
                 type: array
                 items:
                   type: string
+
+    CreatedDatasetId:
+      type: object
+      required: [ id ]
+      properties:
+        id:
+          type: string
+          format: uuid
 
     DatasetsListResponse:
       type: object

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -252,11 +252,16 @@ components:
       type: object
       properties:
         storageSystem:
-          type: string
+          $ref: '#/components/schemas/StorageSystem'
         storageSourceId:
           type: string
         catalogEntry:
           type: string
+
+    StorageSystem:
+      type: string
+      description: The storage system for this dataset
+      enum: ['tdr', 'wks', 'ext']
 
   securitySchemes:
     authorization:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -50,8 +50,106 @@ paths:
                 $ref: '#/components/schemas/DatasetsListResponse'
         '500':
           $ref: '#/components/responses/ServerError'
+    post:
+      tags: [ datasets ]
+      description: Create a new dataset
+      operationId: createDataset
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDatasetRequest'
+        required: true
+      responses:
+        204:
+          description: The catalog entry was created successfully
+          content: { }
+        403:
+          description: No permission to modify metadata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+  /api/v1/datasets/{id}:
+    get:
+      summary: Given a dataset ID, return its catalog entry
+      tags: [ datasets ]
+      operationId: getDataset
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      responses:
+        '200':
+          description: A JSON object of the dataset
+          content:
+            application/json:
+              schema:
+                type: string
+        '404':
+          description: "Dataset not found"
+        '500':
+          $ref: '#/components/responses/ServerError'
+    put:
+      tags: [ datasets ]
+      description: Update the catalog entry for a dataset
+      operationId: updateDataset
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      requestBody:
+        description: The catalog entry to replace existing entry for this dataset
+        content:
+          application/json:
+            schema:
+              type: string
+        required: true
+      responses:
+        204:
+          description: The catalog entry was updated successfully
+          content: { }
+        403:
+          description: No permission to modify metadata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Not found - dataset id does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+    delete:
+      tags: [ datasets ]
+      description: Delete the catalog entry for a dataset
+      operationId: deleteDataset
+      parameters:
+        - $ref: '#/components/parameters/Id'
+      responses:
+        204:
+          description: The catalog entry was deleted successfully
+          content: { }
+        403:
+          description: No permission to modify metadata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Not found - dataset id does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
 
 components:
+  parameters:
+    Id:
+      name: id
+      in: path
+      description: A UUID to used to identify an object in the catalog
+      required: true
+      schema:
+        type: string
+        format: uuid
 
   responses:
     SystemStatusResponse:
@@ -135,6 +233,16 @@ components:
         github:
           type: string
         build:
+          type: string
+
+    CreateDatasetRequest:
+      type: object
+      properties:
+        storageSystem:
+          type: string
+        storageSourceId:
+          type: string
+        catalogEntry:
           type: string
 
   securitySchemes:

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -23,7 +23,10 @@ dependencies {
     implementation 'org.postgresql:postgresql:42.3.3'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation('org.springframework.boot:spring-boot-starter-test') {
+        // Fixes warning about multiple occurrences of JSONObject on the classpath
+        exclude group: 'com.vaadin.external.google', module: 'android-json'
+    }
 }
 
 test {

--- a/service/src/main/java/bio/terra/catalog/api/DatasetApiController.java
+++ b/service/src/main/java/bio/terra/catalog/api/DatasetApiController.java
@@ -2,6 +2,7 @@ package bio.terra.catalog.api;
 
 import bio.terra.catalog.common.StorageSystem;
 import bio.terra.catalog.model.CreateDatasetRequest;
+import bio.terra.catalog.model.CreatedDatasetId;
 import bio.terra.catalog.model.DatasetsListResponse;
 import bio.terra.catalog.service.DatasetService;
 import bio.terra.catalog.service.dataset.DatasetId;
@@ -56,13 +57,14 @@ public class DatasetApiController implements DatasetsApi {
   }
 
   @Override
-  public ResponseEntity<Void> createDataset(CreateDatasetRequest request) {
+  public ResponseEntity<CreatedDatasetId> createDataset(CreateDatasetRequest request) {
     AuthenticatedUserRequest user = getUser();
-    datasetService.createDataset(
-        user,
-        StorageSystem.fromString(request.getStorageSystem()),
-        request.getStorageSourceId(),
-        request.getCatalogEntry());
-    return ResponseEntity.noContent().build();
+    var datasetId =
+        datasetService.createDataset(
+            user,
+            StorageSystem.fromString(request.getStorageSystem()),
+            request.getStorageSourceId(),
+            request.getCatalogEntry());
+    return ResponseEntity.ok(new CreatedDatasetId().id(datasetId.uuid()));
   }
 }

--- a/service/src/main/java/bio/terra/catalog/api/DatasetApiController.java
+++ b/service/src/main/java/bio/terra/catalog/api/DatasetApiController.java
@@ -62,7 +62,7 @@ public class DatasetApiController implements DatasetsApi {
     var datasetId =
         datasetService.createDataset(
             user,
-            StorageSystem.fromString(request.getStorageSystem()),
+            StorageSystem.fromModel(request.getStorageSystem()),
             request.getStorageSourceId(),
             request.getCatalogEntry());
     return ResponseEntity.ok(new CreatedDatasetId().id(datasetId.uuid()));

--- a/service/src/main/java/bio/terra/catalog/api/DatasetApiController.java
+++ b/service/src/main/java/bio/terra/catalog/api/DatasetApiController.java
@@ -1,9 +1,13 @@
 package bio.terra.catalog.api;
 
+import bio.terra.catalog.common.StorageSystem;
+import bio.terra.catalog.model.CreateDatasetRequest;
 import bio.terra.catalog.model.DatasetsListResponse;
 import bio.terra.catalog.service.DatasetService;
+import bio.terra.catalog.service.dataset.DatasetId;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
+import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -25,9 +29,40 @@ public class DatasetApiController implements DatasetsApi {
     this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
   }
 
+  private AuthenticatedUserRequest getUser() {
+    return authenticatedUserRequestFactory.from(request);
+  }
+
   @Override
   public ResponseEntity<DatasetsListResponse> listDatasets() {
-    AuthenticatedUserRequest user = authenticatedUserRequestFactory.from(request);
-    return ResponseEntity.ok(datasetService.listDatasets(user));
+    return ResponseEntity.ok(datasetService.listDatasets(getUser()));
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteDataset(UUID id) {
+    datasetService.deleteMetadata(getUser(), new DatasetId(id));
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<String> getDataset(UUID id) {
+    return ResponseEntity.ok(datasetService.getMetadata(getUser(), new DatasetId(id)));
+  }
+
+  @Override
+  public ResponseEntity<Void> updateDataset(UUID id, String metadata) {
+    datasetService.updateMetadata(getUser(), new DatasetId(id), metadata);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> createDataset(CreateDatasetRequest request) {
+    AuthenticatedUserRequest user = getUser();
+    datasetService.createDataset(
+        user,
+        StorageSystem.fromString(request.getStorageSystem()),
+        request.getStorageSourceId(),
+        request.getCatalogEntry());
+    return ResponseEntity.noContent().build();
   }
 }

--- a/service/src/main/java/bio/terra/catalog/common/DaoKeyHolder.java
+++ b/service/src/main/java/bio/terra/catalog/common/DaoKeyHolder.java
@@ -1,5 +1,6 @@
 package bio.terra.catalog.common;
 
+import bio.terra.catalog.service.dataset.DatasetId;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Map;
@@ -8,8 +9,8 @@ import org.springframework.jdbc.support.GeneratedKeyHolder;
 
 public class DaoKeyHolder extends GeneratedKeyHolder {
 
-  public UUID getId() {
-    return getField("id", UUID.class);
+  public DatasetId getId() {
+    return new DatasetId(getField("id", UUID.class));
   }
 
   public Timestamp getTimestamp(String fieldName) {

--- a/service/src/main/java/bio/terra/catalog/common/StorageSystem.java
+++ b/service/src/main/java/bio/terra/catalog/common/StorageSystem.java
@@ -1,9 +1,9 @@
 package bio.terra.catalog.common;
 
 public enum StorageSystem {
-  TERRA_WORKSPACE("wks"),
-  TERRA_DATA_REPO("tdr"),
-  EXTERNAL("ext");
+  TERRA_WORKSPACE(bio.terra.catalog.model.StorageSystem.WKS.name()),
+  TERRA_DATA_REPO(bio.terra.catalog.model.StorageSystem.TDR.name()),
+  EXTERNAL(bio.terra.catalog.model.StorageSystem.EXT.name());
 
   public final String value;
 
@@ -18,5 +18,13 @@ public enum StorageSystem {
       }
     }
     throw new IllegalArgumentException("Unknown storage system: " + value);
+  }
+
+  public static StorageSystem fromModel(bio.terra.catalog.model.StorageSystem storageSystem) {
+    return fromString(storageSystem.name());
+  }
+
+  public bio.terra.catalog.model.StorageSystem toModel() {
+    return bio.terra.catalog.model.StorageSystem.valueOf(this.value);
   }
 }

--- a/service/src/main/java/bio/terra/catalog/common/StorageSystem.java
+++ b/service/src/main/java/bio/terra/catalog/common/StorageSystem.java
@@ -1,6 +1,22 @@
 package bio.terra.catalog.common;
 
 public enum StorageSystem {
-  TERRA_WORKSPACE,
-  TERRA_DATA_REPO
+  TERRA_WORKSPACE("wks"),
+  TERRA_DATA_REPO("tdr"),
+  EXTERNAL("ext");
+
+  public final String value;
+
+  StorageSystem(String value) {
+    this.value = value;
+  }
+
+  public static StorageSystem fromString(String value) {
+    for (StorageSystem system : values()) {
+      if (system.value.equals(value)) {
+        return system;
+      }
+    }
+    throw new IllegalArgumentException("Unknown storage system: " + value);
+  }
 }

--- a/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
+++ b/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class DatarepoService {
   private static final Logger logger = LoggerFactory.getLogger(DatarepoService.class);
-  public static final String OWNER_ROLE_NAME = "owner";
+  public static final String OWNER_ROLE_NAME = "admin";
   private final DatarepoConfiguration datarepoConfig;
   private final Client commonHttpClient;
 

--- a/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
+++ b/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
@@ -24,12 +24,10 @@ public class DatarepoService {
   private static final Logger logger = LoggerFactory.getLogger(DatarepoService.class);
   public static final String ADMIN_ROLE_NAME = "admin";
   public static final String CUSTODIAN_ROLE_NAME = "custodian";
-  public static final String STEWARD_ROLE_NAwME = "steward";
   public static final String READER_ROLE_NAME = "reader";
   public static final String DISCOVERER_ROLE_NAME = "discoverer";
 
-  private static final List<String> OWNER_ROLES =
-      List.of(ADMIN_ROLE_NAME, CUSTODIAN_ROLE_NAME, STEWARD_ROLE_NAwME);
+  private static final List<String> OWNER_ROLES = List.of(ADMIN_ROLE_NAME, CUSTODIAN_ROLE_NAME);
   private static final List<String> READER_ROLES =
       List.of(ADMIN_ROLE_NAME, CUSTODIAN_ROLE_NAME, READER_ROLE_NAME, DISCOVERER_ROLE_NAME);
 

--- a/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
+++ b/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
@@ -24,10 +24,12 @@ public class DatarepoService {
   private static final Logger logger = LoggerFactory.getLogger(DatarepoService.class);
   public static final String ADMIN_ROLE_NAME = "admin";
   public static final String CUSTODIAN_ROLE_NAME = "custodian";
+  public static final String STEWARD_ROLE_NAwME = "steward";
   public static final String READER_ROLE_NAME = "reader";
   public static final String DISCOVERER_ROLE_NAME = "discoverer";
 
-  private static final List<String> OWNER_ROLES = List.of(ADMIN_ROLE_NAME, CUSTODIAN_ROLE_NAME);
+  private static final List<String> OWNER_ROLES =
+      List.of(ADMIN_ROLE_NAME, CUSTODIAN_ROLE_NAME, STEWARD_ROLE_NAwME);
   private static final List<String> READER_ROLES =
       List.of(ADMIN_ROLE_NAME, CUSTODIAN_ROLE_NAME, READER_ROLE_NAME, DISCOVERER_ROLE_NAME);
 

--- a/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
+++ b/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
@@ -83,13 +83,16 @@ public class DatarepoService {
     return new ApiClient().setHttpClient(commonHttpClient).setBasePath(datarepoConfig.basePath());
   }
 
+  @VisibleForTesting
+  UnauthenticatedApi unauthenticatedApi() {
+    return new UnauthenticatedApi(getApiClient());
+  }
+
   public SystemStatusSystems status() {
-    // No access token needed since this is an unauthenticated API.
-    UnauthenticatedApi api = new UnauthenticatedApi(getApiClient());
     var result = new SystemStatusSystems();
     try {
       // Don't retry status check
-      RepositoryStatusModel status = api.serviceStatus();
+      RepositoryStatusModel status = unauthenticatedApi().serviceStatus();
       result.ok(status.isOk());
       // Populate error message if system status is non-ok
       if (!result.isOk()) {

--- a/service/src/main/java/bio/terra/catalog/iam/SamAction.java
+++ b/service/src/main/java/bio/terra/catalog/iam/SamAction.java
@@ -9,16 +9,16 @@ public enum SamAction {
   UPDATE_ANY_METADATA("update_any_metadata"),
   DELETE_ANY_METADATA("delete_any_metadata");
 
-  public final String name;
+  public final String value;
 
   SamAction(String samActionName) {
-    this.name = samActionName;
+    this.value = samActionName;
   }
 
   @JsonCreator
   static SamAction fromValue(String text) {
     return Arrays.stream(values())
-        .filter(action -> action.name.equalsIgnoreCase(text))
+        .filter(action -> action.value.equalsIgnoreCase(text))
         .findFirst()
         .orElse(null);
   }

--- a/service/src/main/java/bio/terra/catalog/iam/SamAction.java
+++ b/service/src/main/java/bio/terra/catalog/iam/SamAction.java
@@ -9,7 +9,7 @@ public enum SamAction {
   UPDATE_ANY_METADATA("update_any_metadata"),
   DELETE_ANY_METADATA("delete_any_metadata");
 
-  private final String name;
+  public final String name;
 
   SamAction(String samActionName) {
     this.name = samActionName;

--- a/service/src/main/java/bio/terra/catalog/iam/SamAction.java
+++ b/service/src/main/java/bio/terra/catalog/iam/SamAction.java
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;
 
 public enum SamAction {
-  ALTER_ENTRY("alter_entry");
+  CREATE_METADATA("create_metadata"),
+  READ_ANY_METADATA("read_any_metadata"),
+  UPDATE_ANY_METADATA("update_any_metadata"),
+  DELETE_ANY_METADATA("delete_any_metadata");
 
   private final String name;
 

--- a/service/src/main/java/bio/terra/catalog/iam/SamService.java
+++ b/service/src/main/java/bio/terra/catalog/iam/SamService.java
@@ -36,16 +36,16 @@ public class SamService {
   }
 
   /**
-   * Checks if a user has any action on a resource.
+   * Checks if a user has an action on all catalog resources.
    *
-   * <p>If user has any action on a resource than we allow that user to list the resource, rather
-   * than have a specific action for listing. That is the Sam convention.
+   * <p>This checks the action against the "global" catalog resource, which is where permissions
+   * for global operations are kept.
    *
    * @param userRequest authenticated user
    * @param action sam action
    * @return true if the user has any actions on that resource; false otherwise.
    */
-  public boolean hasAction(AuthenticatedUserRequest userRequest, SamAction action) {
+  public boolean hasGlobalAction(AuthenticatedUserRequest userRequest, SamAction action) {
     String accessToken = userRequest.getToken();
     ResourcesApi resourceApi = resourcesApi(accessToken);
     try {

--- a/service/src/main/java/bio/terra/catalog/iam/SamService.java
+++ b/service/src/main/java/bio/terra/catalog/iam/SamService.java
@@ -38,8 +38,8 @@ public class SamService {
   /**
    * Checks if a user has an action on all catalog resources.
    *
-   * <p>This checks the action against the "global" catalog resource, which is where permissions
-   * for global operations are kept.
+   * <p>This checks the action against the "global" catalog resource, which is used for global
+   * permission checks.
    *
    * @param userRequest authenticated user
    * @param action sam action

--- a/service/src/main/java/bio/terra/catalog/iam/SamService.java
+++ b/service/src/main/java/bio/terra/catalog/iam/SamService.java
@@ -57,6 +57,7 @@ public class SamService {
     } catch (ApiException e) {
       throw SamExceptionFactory.create("Error checking resource permission in Sam", e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw SamExceptionFactory.create("Error checking resource permission in Sam", e);
     }
   }
@@ -74,6 +75,7 @@ public class SamService {
     } catch (ApiException e) {
       throw SamExceptionFactory.create("Error getting user email from Sam", e);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw SamExceptionFactory.create("Error getting user email from Sam", e);
     }
   }

--- a/service/src/main/java/bio/terra/catalog/iam/SamService.java
+++ b/service/src/main/java/bio/terra/catalog/iam/SamService.java
@@ -26,6 +26,9 @@ public class SamService {
   private final SamConfiguration samConfig;
   private final OkHttpClient commonHttpClient;
 
+  private static final String CATALOG_RESOURCE_TYPE = "catalog";
+  private static final String CATALOG_RESOURCE_ID = "catalog";
+
   @Autowired
   public SamService(SamConfiguration samConfig) {
     this.samConfig = samConfig;
@@ -47,7 +50,10 @@ public class SamService {
     ResourcesApi resourceApi = samResourcesApi(accessToken);
     try {
       return SamRetry.retry(
-          () -> resourceApi.resourceActions(null, null).contains(action.toString()));
+          () ->
+              resourceApi
+                  .resourceActions(CATALOG_RESOURCE_TYPE, CATALOG_RESOURCE_ID)
+                  .contains(action.toString()));
     } catch (ApiException e) {
       throw SamExceptionFactory.create("Error checking resource permission in Sam", e);
     } catch (InterruptedException e) {

--- a/service/src/main/java/bio/terra/catalog/iam/SamService.java
+++ b/service/src/main/java/bio/terra/catalog/iam/SamService.java
@@ -42,14 +42,15 @@ public class SamService {
    * @param action sam action
    * @return true if the user has any actions on that resource; false otherwise.
    */
-  public boolean hasAction(AuthenticatedUserRequest userRequest, SamAction action)
-      throws InterruptedException {
+  public boolean hasAction(AuthenticatedUserRequest userRequest, SamAction action) {
     String accessToken = userRequest.getToken();
     ResourcesApi resourceApi = samResourcesApi(accessToken);
     try {
       return SamRetry.retry(
           () -> resourceApi.resourceActions(null, null).contains(action.toString()));
     } catch (ApiException e) {
+      throw SamExceptionFactory.create("Error checking resource permission in Sam", e);
+    } catch (InterruptedException e) {
       throw SamExceptionFactory.create("Error checking resource permission in Sam", e);
     }
   }
@@ -60,12 +61,14 @@ public class SamService {
    * @param userToken user token
    * @return {@link UserStatusInfo}
    */
-  public UserStatusInfo getUserStatusInfo(String userToken) throws InterruptedException {
+  public UserStatusInfo getUserStatusInfo(String userToken) {
     UsersApi usersApi = samUsersApi(userToken);
     try {
       return SamRetry.retry(usersApi::getUserStatusInfo);
     } catch (ApiException e) {
       throw SamExceptionFactory.create("Error getting user email from Sam", e);
+    } catch (InterruptedException e) {
+      throw SamExceptionFactory.create("Error checking resource permission in Sam", e);
     }
   }
 

--- a/service/src/main/java/bio/terra/catalog/iam/SamService.java
+++ b/service/src/main/java/bio/terra/catalog/iam/SamService.java
@@ -74,7 +74,7 @@ public class SamService {
     } catch (ApiException e) {
       throw SamExceptionFactory.create("Error getting user email from Sam", e);
     } catch (InterruptedException e) {
-      throw SamExceptionFactory.create("Error checking resource permission in Sam", e);
+      throw SamExceptionFactory.create("Error getting user email from Sam", e);
     }
   }
 

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -71,8 +71,6 @@ public class DatasetService {
 
   public String getMetadata(AuthenticatedUserRequest user, DatasetId datasetId) {
     var dataset = datasetDao.retrieve(datasetId);
-    // This check isn't correct as it checks for owner, but it should check for reader or
-    // discoverer.
     ensureActionPermission(user, dataset, SamAction.READ_ANY_METADATA);
     return dataset.metadata();
   }

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -84,7 +84,7 @@ public class DatasetService {
       StorageSystem storageSystem,
       String storageSourceId,
       String metadata) {
-    var dataset = new Dataset(null, storageSourceId, StorageSystem.EXTERNAL, metadata, null);
+    var dataset = new Dataset(null, storageSourceId, storageSystem, metadata, null);
     ensureActionPermission(user, dataset, SamAction.UPDATE_ANY_METADATA);
     datasetDao.create(dataset);
   }

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -61,7 +61,8 @@ public class DatasetService {
     // can either have permission granted by the storage system that owns the dataset, or if
     // they're a catalog admin user who has permission to perform any operation on any
     // catalog entry.
-    if (!checkStoragePermission(user, dataset, action) && !samService.hasGlobalAction(user, action)) {
+    if (!checkStoragePermission(user, dataset, action)
+        && !samService.hasGlobalAction(user, action)) {
       throw new UnauthorizedException(
           String.format("User %s does not have permission to %s", user.getEmail(), action));
     }

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -86,7 +86,7 @@ public class DatasetService {
       StorageSystem storageSystem,
       String storageSourceId,
       String metadata) {
-    var dataset = new Dataset(null, storageSourceId, storageSystem, metadata, null);
+    var dataset = new Dataset(storageSourceId, storageSystem, metadata);
     ensureActionPermission(user, dataset, SamAction.UPDATE_ANY_METADATA);
     return datasetDao.create(dataset).id();
   }

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -57,7 +57,11 @@ public class DatasetService {
 
   private void ensureActionPermission(
       AuthenticatedUserRequest user, Dataset dataset, SamAction action) {
-    if (!checkStoragePermission(user, dataset, action) && !samService.hasAction(user, action)) {
+    // Ensure that the current user has permission to perform this action. The current user
+    // can either have permission granted by the storage system that owns the dataset, or if
+    // they're a catalog admin user who has permission to perform any operation on any
+    // catalog entry.
+    if (!checkStoragePermission(user, dataset, action) && !samService.hasGlobalAction(user, action)) {
       throw new UnauthorizedException(
           String.format("User %s does not have permission to %s", user.getEmail(), action));
     }

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -87,7 +87,7 @@ public class DatasetService {
       String storageSourceId,
       String metadata) {
     var dataset = new Dataset(storageSourceId, storageSystem, metadata);
-    ensureActionPermission(user, dataset, SamAction.UPDATE_ANY_METADATA);
+    ensureActionPermission(user, dataset, SamAction.CREATE_METADATA);
     return datasetDao.create(dataset).id();
   }
 }

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -46,16 +46,18 @@ public class DatasetService {
     return response;
   }
 
-  private boolean isOwner(AuthenticatedUserRequest user, Dataset dataset) {
+  private boolean checkStoragePermission(
+      AuthenticatedUserRequest user, Dataset dataset, SamAction action) {
     return switch (dataset.storageSystem()) {
-      case TERRA_DATA_REPO -> datarepoService.isOwner(user, dataset.storageSourceId());
+      case TERRA_DATA_REPO -> datarepoService.userHasAction(
+          user, dataset.storageSourceId(), action);
       case TERRA_WORKSPACE, EXTERNAL -> false;
     };
   }
 
   private void ensureActionPermission(
       AuthenticatedUserRequest user, Dataset dataset, SamAction action) {
-    if (!isOwner(user, dataset) && !samService.hasAction(user, action)) {
+    if (!checkStoragePermission(user, dataset, action) && !samService.hasAction(user, action)) {
       throw new UnauthorizedException(
           String.format("User %s does not have permission to %s", user.getEmail(), action));
     }

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -69,6 +69,8 @@ public class DatasetService {
 
   public String getMetadata(AuthenticatedUserRequest user, DatasetId datasetId) {
     var dataset = datasetDao.retrieve(datasetId);
+    // This check isn't correct as it checks for owner, but it should check for reader or
+    // discoverer.
     ensureActionPermission(user, dataset, SamAction.READ_ANY_METADATA);
     return dataset.metadata();
   }
@@ -79,13 +81,13 @@ public class DatasetService {
     datasetDao.update(dataset.withMetadata(metadata));
   }
 
-  public void createDataset(
+  public DatasetId createDataset(
       AuthenticatedUserRequest user,
       StorageSystem storageSystem,
       String storageSourceId,
       String metadata) {
     var dataset = new Dataset(null, storageSourceId, storageSystem, metadata, null);
     ensureActionPermission(user, dataset, SamAction.UPDATE_ANY_METADATA);
-    datasetDao.create(dataset);
+    return datasetDao.create(dataset).id();
   }
 }

--- a/service/src/main/java/bio/terra/catalog/service/dataset/Dataset.java
+++ b/service/src/main/java/bio/terra/catalog/service/dataset/Dataset.java
@@ -2,11 +2,20 @@ package bio.terra.catalog.service.dataset;
 
 import bio.terra.catalog.common.StorageSystem;
 import java.time.Instant;
-import java.util.UUID;
 
 public record Dataset(
-    UUID id,
+    DatasetId id,
     String storageSourceId,
     StorageSystem storageSystem,
     String metadata,
-    Instant createdDate) {}
+    Instant createdDate) {
+
+  /**
+   * Create a new Dataset with the given metadata
+   *
+   * @param metadata the metadata to store
+   */
+  public Dataset withMetadata(String metadata) {
+    return new Dataset(id, storageSourceId, storageSystem, metadata, createdDate);
+  }
+}

--- a/service/src/main/java/bio/terra/catalog/service/dataset/Dataset.java
+++ b/service/src/main/java/bio/terra/catalog/service/dataset/Dataset.java
@@ -8,7 +8,11 @@ public record Dataset(
     String storageSourceId,
     StorageSystem storageSystem,
     String metadata,
-    Instant createdDate) {
+    Instant creationTime) {
+
+  public Dataset(String storageSourceId, StorageSystem storageSystem, String metadata) {
+    this(null, storageSourceId, storageSystem, metadata, null);
+  }
 
   /**
    * Create a new Dataset with the given metadata
@@ -16,6 +20,6 @@ public record Dataset(
    * @param metadata the metadata to store
    */
   public Dataset withMetadata(String metadata) {
-    return new Dataset(id, storageSourceId, storageSystem, metadata, createdDate);
+    return new Dataset(storageSourceId, storageSystem, metadata);
   }
 }

--- a/service/src/main/java/bio/terra/catalog/service/dataset/Dataset.java
+++ b/service/src/main/java/bio/terra/catalog/service/dataset/Dataset.java
@@ -20,6 +20,6 @@ public record Dataset(
    * @param metadata the metadata to store
    */
   public Dataset withMetadata(String metadata) {
-    return new Dataset(storageSourceId, storageSystem, metadata);
+    return new Dataset(id, storageSourceId, storageSystem, metadata, creationTime);
   }
 }

--- a/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
+++ b/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
@@ -50,13 +50,13 @@ public class DatasetDao {
     try {
       return jdbcTemplate.queryForObject(sql, params, new DatasetMapper());
     } catch (EmptyResultDataAccessException ex) {
-      throw new DatasetNotFoundException("Dataset not found for id " + id, ex);
+      throw new DatasetNotFoundException("Dataset not found for " + id, ex);
     }
   }
 
   private Dataset createOrUpdate(String sql, MapSqlParameterSource params) {
     DaoKeyHolder keyHolder = new DaoKeyHolder();
-    int rowsAffected = 0;
+    int rowsAffected;
     try {
       rowsAffected = jdbcTemplate.update(sql, params, keyHolder);
     } catch (DuplicateKeyException ex) {

--- a/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
+++ b/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
@@ -43,10 +43,10 @@ public class DatasetDao {
   }
 
   @ReadTransaction
-  public Dataset retrieve(UUID id) {
+  public Dataset retrieve(DatasetId id) {
     String sql =
         "SELECT id, storage_source_id, storage_system, metadata, created_date FROM dataset WHERE id = :id";
-    MapSqlParameterSource params = new MapSqlParameterSource().addValue(ID_FIELD, id);
+    MapSqlParameterSource params = new MapSqlParameterSource().addValue(ID_FIELD, id.uuid());
     try {
       return jdbcTemplate.queryForObject(sql, params, new DatasetMapper());
     } catch (EmptyResultDataAccessException ex) {
@@ -96,7 +96,7 @@ public class DatasetDao {
             + "WHERE id = :id";
     MapSqlParameterSource params =
         new MapSqlParameterSource()
-            .addValue(ID_FIELD, dataset.id())
+            .addValue(ID_FIELD, dataset.id().uuid())
             .addValue(STORAGE_SOURCE_ID_FIELD, dataset.storageSourceId())
             .addValue(STORAGE_SYSTEM_FIELD, String.valueOf(dataset.storageSystem()))
             .addValue(METADATA_FIELD, dataset.metadata());
@@ -104,9 +104,10 @@ public class DatasetDao {
   }
 
   @WriteTransaction
-  public boolean delete(UUID id) {
+  public boolean delete(Dataset dataset) {
     String sql = "DELETE FROM dataset WHERE id = :id";
-    MapSqlParameterSource params = new MapSqlParameterSource().addValue(ID_FIELD, id);
+    MapSqlParameterSource params =
+        new MapSqlParameterSource().addValue(ID_FIELD, dataset.id().uuid());
     int rowsAffected = jdbcTemplate.update(sql, params);
     return rowsAffected > 0;
   }
@@ -114,7 +115,7 @@ public class DatasetDao {
   private static class DatasetMapper implements RowMapper<Dataset> {
     public Dataset mapRow(ResultSet rs, int rowNum) throws SQLException {
       return new Dataset(
-          rs.getObject(ID_FIELD, UUID.class),
+          new DatasetId(rs.getObject(ID_FIELD, UUID.class)),
           rs.getString(STORAGE_SOURCE_ID_FIELD),
           StorageSystem.valueOf(rs.getString(STORAGE_SYSTEM_FIELD)),
           rs.getString(METADATA_FIELD),

--- a/service/src/main/java/bio/terra/catalog/service/dataset/DatasetId.java
+++ b/service/src/main/java/bio/terra/catalog/service/dataset/DatasetId.java
@@ -1,0 +1,5 @@
+package bio.terra.catalog.service.dataset;
+
+import java.util.UUID;
+
+public record DatasetId(UUID uuid) {}

--- a/service/src/test/java/bio/terra/catalog/api/DatasetApiControllerTest.java
+++ b/service/src/test/java/bio/terra/catalog/api/DatasetApiControllerTest.java
@@ -100,7 +100,7 @@ class DatasetApiControllerTest {
     var id = "sourceId";
     var request =
         new CreateDatasetRequest()
-            .storageSystem(storageSystem.value)
+            .storageSystem(storageSystem.toModel())
             .storageSourceId(id)
             .catalogEntry(METADATA);
     var uuid = UUID.randomUUID();
@@ -114,20 +114,4 @@ class DatasetApiControllerTest {
         .andExpect(jsonPath("$.id").value(uuid.toString()));
     verify(datasetService).createDataset(user, storageSystem, id, METADATA);
   }
-
-  /*
-  @Test
-  void createDatasetInvalidStorageSystem() throws Exception {
-    var id = "sourceId";
-    var request =
-        new CreateDatasetRequest()
-            .storageSystem("unknown")
-            .storageSourceId(id)
-            .catalogEntry(METADATA);
-    var postBody = new ObjectMapper().writeValueAsString(request);
-    mockMvc
-        .perform(post(API).contentType(MediaType.APPLICATION_JSON).content(postBody))
-        .andExpect(status().isInternalServerError());
-  }
-  */
 }

--- a/service/src/test/java/bio/terra/catalog/api/DatasetApiControllerTest.java
+++ b/service/src/test/java/bio/terra/catalog/api/DatasetApiControllerTest.java
@@ -103,10 +103,15 @@ class DatasetApiControllerTest {
             .storageSystem(storageSystem.value)
             .storageSourceId(id)
             .catalogEntry(METADATA);
+    var uuid = UUID.randomUUID();
+    when(datasetService.createDataset(user, storageSystem, id, METADATA))
+        .thenReturn(new DatasetId(uuid));
     var postBody = new ObjectMapper().writeValueAsString(request);
     mockMvc
         .perform(post(API).contentType(MediaType.APPLICATION_JSON).content(postBody))
-        .andExpect(status().is2xxSuccessful());
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id").value(uuid.toString()));
     verify(datasetService).createDataset(user, storageSystem, id, METADATA);
   }
 

--- a/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
@@ -1,0 +1,17 @@
+package bio.terra.catalog.datarepo;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class DatarepoServiceTest {
+
+  @Test
+  void getSnapshots() {}
+
+  @Test
+  void userHasAction() {}
+
+  @Test
+  void status() {}
+}

--- a/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
@@ -71,8 +71,7 @@ class DatarepoServiceTest {
     var id = UUID.randomUUID();
     when(snapshotsApi.retrieveUserSnapshotRoles(id))
         .thenReturn(List.of(DatarepoService.READER_ROLE_NAME));
-    assertThat(
-        datarepoService.userHasAction(user, id.toString(), SamAction.READ_ANY_METADATA), is(true));
+    assertTrue(datarepoService.userHasAction(user, id.toString(), SamAction.READ_ANY_METADATA));
   }
 
   @Test
@@ -80,8 +79,7 @@ class DatarepoServiceTest {
     var id = UUID.randomUUID();
     when(snapshotsApi.retrieveUserSnapshotRoles(id))
         .thenReturn(List.of(DatarepoService.ADMIN_ROLE_NAME));
-    assertThat(
-        datarepoService.userHasAction(user, id.toString(), SamAction.CREATE_METADATA), is(true));
+    assertTrue(datarepoService.userHasAction(user, id.toString(), SamAction.CREATE_METADATA));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
@@ -1,17 +1,118 @@
 package bio.terra.catalog.datarepo;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
+import bio.terra.catalog.iam.SamAction;
+import bio.terra.catalog.model.SystemStatusSystems;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.datarepo.api.SnapshotsApi;
+import bio.terra.datarepo.api.UnauthenticatedApi;
+import bio.terra.datarepo.client.ApiException;
+import bio.terra.datarepo.model.EnumerateSnapshotModel;
+import bio.terra.datarepo.model.RepositoryStatusModel;
+import bio.terra.datarepo.model.SnapshotSummaryModel;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ConfigurationPropertiesScan("bio.terra.catalog")
+@ContextConfiguration(classes = {DatarepoService.class})
 class DatarepoServiceTest {
 
-  @Test
-  void getSnapshots() {}
+  @Autowired private DatarepoService datarepoServiceReal;
+
+  @Mock AuthenticatedUserRequest user;
+
+  @MockBean SnapshotsApi snapshotsApi;
+
+  @MockBean UnauthenticatedApi unauthenticatedApi;
+
+  private DatarepoService datarepoService;
+
+  @BeforeEach
+  void beforeEach() {
+    datarepoService = spy(datarepoServiceReal);
+    doReturn(snapshotsApi).when(datarepoService).snapshotsApi(user);
+    doReturn(unauthenticatedApi).when(datarepoService).unauthenticatedApi();
+  }
 
   @Test
-  void userHasAction() {}
+  void getSnapshots() throws Exception {
+    var items = List.of(new SnapshotSummaryModel());
+    var esm = new EnumerateSnapshotModel().items(items);
+    when(snapshotsApi.enumerateSnapshots(any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(esm);
+    assertThat(datarepoService.getSnapshots(user), is(items));
+  }
 
   @Test
-  void status() {}
+  void getSnapshotsException() throws Exception {
+    when(snapshotsApi.enumerateSnapshots(any(), any(), any(), any(), any(), any(), any()))
+        .thenThrow(new ApiException());
+    assertThrows(DatarepoException.class, () -> datarepoService.getSnapshots(user));
+  }
+
+  @Test
+  void userHasActionReader() throws Exception {
+    var id = UUID.randomUUID();
+    when(snapshotsApi.retrieveUserSnapshotRoles(id))
+        .thenReturn(List.of(DatarepoService.READER_ROLE_NAME));
+    assertThat(
+        datarepoService.userHasAction(user, id.toString(), SamAction.READ_ANY_METADATA), is(true));
+  }
+
+  @Test
+  void userHasActionOwner() throws Exception {
+    var id = UUID.randomUUID();
+    when(snapshotsApi.retrieveUserSnapshotRoles(id))
+        .thenReturn(List.of(DatarepoService.ADMIN_ROLE_NAME));
+    assertThat(
+        datarepoService.userHasAction(user, id.toString(), SamAction.CREATE_METADATA), is(true));
+  }
+
+  @Test
+  void userHasActionException() throws Exception {
+    var id = UUID.randomUUID();
+    when(snapshotsApi.retrieveUserSnapshotRoles(id)).thenThrow(new ApiException());
+    assertThrows(
+        DatarepoException.class,
+        () -> datarepoService.userHasAction(user, id.toString(), SamAction.CREATE_METADATA));
+  }
+
+  @Test
+  void statusOk() throws Exception {
+    when(unauthenticatedApi.serviceStatus()).thenReturn(new RepositoryStatusModel().ok(true));
+    assertThat(datarepoService.status(), is(new SystemStatusSystems().ok(true)));
+  }
+
+  @Test
+  void statusDown() throws Exception {
+    when(unauthenticatedApi.serviceStatus()).thenReturn(new RepositoryStatusModel().ok(false));
+    var status = datarepoService.status();
+    assertFalse(status.isOk());
+  }
+
+  @Test
+  void statusException() throws Exception {
+    when(unauthenticatedApi.serviceStatus()).thenThrow(new ApiException());
+    var status = datarepoService.status();
+    assertFalse(status.isOk());
+  }
 }

--- a/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
@@ -26,7 +26,6 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -39,10 +38,8 @@ class DatarepoServiceTest {
   @Autowired private DatarepoService datarepoServiceReal;
 
   @Mock private AuthenticatedUserRequest user;
-
-  @MockBean private SnapshotsApi snapshotsApi;
-
-  @MockBean private UnauthenticatedApi unauthenticatedApi;
+  @Mock private SnapshotsApi snapshotsApi;
+  @Mock private UnauthenticatedApi unauthenticatedApi;
 
   private DatarepoService datarepoService;
 

--- a/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
@@ -88,9 +88,10 @@ class DatarepoServiceTest {
   void userHasActionException() throws Exception {
     var id = UUID.randomUUID();
     when(snapshotsApi.retrieveUserSnapshotRoles(id)).thenThrow(new ApiException());
+    var stringId = id.toString();
     assertThrows(
         DatarepoException.class,
-        () -> datarepoService.userHasAction(user, id.toString(), SamAction.CREATE_METADATA));
+        () -> datarepoService.userHasAction(user, stringId, SamAction.CREATE_METADATA));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
@@ -38,11 +38,11 @@ class DatarepoServiceTest {
 
   @Autowired private DatarepoService datarepoServiceReal;
 
-  @Mock AuthenticatedUserRequest user;
+  @Mock private AuthenticatedUserRequest user;
 
-  @MockBean SnapshotsApi snapshotsApi;
+  @MockBean private SnapshotsApi snapshotsApi;
 
-  @MockBean UnauthenticatedApi unauthenticatedApi;
+  @MockBean private UnauthenticatedApi unauthenticatedApi;
 
   private DatarepoService datarepoService;
 

--- a/service/src/test/java/bio/terra/catalog/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/iam/SamServiceTest.java
@@ -1,0 +1,92 @@
+package bio.terra.catalog.iam;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import java.util.List;
+import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
+import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ConfigurationPropertiesScan("bio.terra.catalog")
+@ContextConfiguration(classes = {SamService.class})
+class SamServiceTest {
+
+  @Autowired private SamService samServiceReal;
+
+  @Mock private UsersApi usersApi;
+  @Mock private ResourcesApi resourcesApi;
+  @Mock private StatusApi statusApi;
+
+  private static final String USER_TOKEN = "token";
+  private static final AuthenticatedUserRequest USER =
+      AuthenticatedUserRequest.builder().setToken(USER_TOKEN).setEmail("").setSubjectId("").build();
+
+  private SamService samService;
+
+  @BeforeEach
+  void beforeEach() {
+    samService = spy(samServiceReal);
+    doReturn(usersApi).when(samService).usersApi(USER_TOKEN);
+    doReturn(resourcesApi).when(samService).resourcesApi(USER_TOKEN);
+    doReturn(statusApi).when(samService).statusApi();
+  }
+
+  @Test
+  void hasAction() throws Exception {
+    var action = SamAction.READ_ANY_METADATA;
+    when(resourcesApi.resourceActions(any(), any())).thenReturn(List.of(action.name));
+    assertTrue(samService.hasAction(USER, action));
+  }
+
+  @Test
+  void getUserStatusInfo() throws Exception {
+    UserStatusInfo userStatusInfo = new UserStatusInfo();
+    when(usersApi.getUserStatusInfo()).thenReturn(userStatusInfo);
+    assertThat(userStatusInfo, is(samService.getUserStatusInfo(USER_TOKEN)));
+  }
+
+  @Test
+  void status() throws Exception {
+    SystemStatus status = new SystemStatus().ok(true);
+    when(statusApi.getSystemStatus()).thenReturn(status);
+    var samStatus = samService.status();
+    assertTrue(samStatus.isOk());
+  }
+
+  @Test
+  void statusDown() throws Exception {
+    SystemStatus status = new SystemStatus().ok(false);
+    when(statusApi.getSystemStatus()).thenReturn(status);
+    var samStatus = samService.status();
+    assertFalse(samStatus.isOk());
+  }
+
+  @Test
+  void statusException() throws Exception {
+    when(statusApi.getSystemStatus()).thenThrow(new ApiException());
+    var samStatus = samService.status();
+    assertFalse(samStatus.isOk());
+  }
+}

--- a/service/src/test/java/bio/terra/catalog/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/iam/SamServiceTest.java
@@ -56,7 +56,7 @@ class SamServiceTest {
   @Test
   void hasAction() throws Exception {
     var action = SamAction.READ_ANY_METADATA;
-    when(resourcesApi.resourceActions(any(), any())).thenReturn(List.of(action.name));
+    when(resourcesApi.resourceActions(any(), any())).thenReturn(List.of(action.value));
     assertTrue(samService.hasAction(USER, action));
   }
 

--- a/service/src/test/java/bio/terra/catalog/iam/SamServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/iam/SamServiceTest.java
@@ -57,7 +57,7 @@ class SamServiceTest {
   void hasAction() throws Exception {
     var action = SamAction.READ_ANY_METADATA;
     when(resourcesApi.resourceActions(any(), any())).thenReturn(List.of(action.value));
-    assertTrue(samService.hasAction(USER, action));
+    assertTrue(samService.hasGlobalAction(USER, action));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -95,7 +95,8 @@ class DatasetServiceTest {
     var tdrDataset = new Dataset(datasetId, sourceId, StorageSystem.TERRA_DATA_REPO, null, null);
     reset(datasetDao);
     when(datasetDao.retrieve(datasetId)).thenReturn(tdrDataset);
-    when(datarepoService.isOwner(user, sourceId)).thenReturn(true);
+    when(datarepoService.userHasAction(user, sourceId, SamAction.READ_ANY_METADATA))
+        .thenReturn(true);
     datasetService.getMetadata(user, datasetId);
     verify(datasetDao).retrieve(datasetId);
   }

--- a/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -1,0 +1,59 @@
+package bio.terra.catalog.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
+
+import bio.terra.catalog.config.BeanConfig;
+import bio.terra.catalog.datarepo.DatarepoService;
+import bio.terra.catalog.service.dataset.DatasetId;
+import bio.terra.common.iam.AuthenticatedUserRequest;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ContextConfiguration(classes = {DatasetService.class, BeanConfig.class})
+class DatasetServiceTest {
+
+  @Autowired private DatasetService datasetService;
+
+  @MockBean private DatarepoService datarepoService;
+
+  private final AuthenticatedUserRequest user = mock(AuthenticatedUserRequest.class);
+
+  private final DatasetId datasetId = new DatasetId(UUID.randomUUID());
+
+  @Test
+  void listDatasets() {
+    var result = datasetService.listDatasets(user);
+    assertThat(result, is(notNullValue()));
+  }
+
+  @Test
+  void deleteMetadata() {
+    datasetService.deleteMetadata(user, datasetId);
+  }
+
+  @Test
+  void getMetadata() {
+    datasetService.getMetadata(user, datasetId);
+  }
+
+  @Test
+  void updateMetadata() {
+    datasetService.updateMetadata(user, datasetId, "test");
+  }
+
+  @Test
+  void createDataset() {
+
+  }
+}

--- a/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -73,7 +73,7 @@ class DatasetServiceTest {
 
   @Test()
   void testDeleteMetadata() {
-    when(samService.hasAction(user, SamAction.DELETE_ANY_METADATA)).thenReturn(true);
+    when(samService.hasGlobalAction(user, SamAction.DELETE_ANY_METADATA)).thenReturn(true);
     datasetService.deleteMetadata(user, datasetId);
     verify(datasetDao).delete(dataset);
   }
@@ -85,7 +85,7 @@ class DatasetServiceTest {
 
   @Test
   void testGetMetadata() {
-    when(samService.hasAction(user, SamAction.READ_ANY_METADATA)).thenReturn(true);
+    when(samService.hasGlobalAction(user, SamAction.READ_ANY_METADATA)).thenReturn(true);
     datasetService.getMetadata(user, datasetId);
     verify(datasetDao).retrieve(datasetId);
   }
@@ -110,7 +110,7 @@ class DatasetServiceTest {
   @Test
   void testUpdateMetadata() {
     String metadata = "test metadata";
-    when(samService.hasAction(user, SamAction.UPDATE_ANY_METADATA)).thenReturn(true);
+    when(samService.hasGlobalAction(user, SamAction.UPDATE_ANY_METADATA)).thenReturn(true);
     datasetService.updateMetadata(user, datasetId, metadata);
     verify(datasetDao).update(dataset.withMetadata(metadata));
   }
@@ -131,7 +131,7 @@ class DatasetServiceTest {
         new Dataset(
             datasetId, storageSourceId, StorageSystem.TERRA_DATA_REPO, metadata, Instant.now());
 
-    when(samService.hasAction(user, SamAction.CREATE_METADATA)).thenReturn(true);
+    when(samService.hasGlobalAction(user, SamAction.CREATE_METADATA)).thenReturn(true);
     when(datasetDao.create(testDataset)).thenReturn(testDatasetWithCreationInfo);
     DatasetId id =
         datasetService.createDataset(

--- a/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -53,7 +53,7 @@ class DatasetServiceTest {
       new Dataset(datasetId, sourceId, StorageSystem.EXTERNAL, null, null);
 
   @BeforeEach
-  public void setup() {
+  public void beforeEach() {
     when(datasetDao.retrieve(datasetId)).thenReturn(dataset);
   }
 

--- a/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -131,7 +131,7 @@ class DatasetServiceTest {
         new Dataset(
             datasetId, storageSourceId, StorageSystem.TERRA_DATA_REPO, metadata, Instant.now());
 
-    when(samService.hasAction(user, SamAction.UPDATE_ANY_METADATA)).thenReturn(true);
+    when(samService.hasAction(user, SamAction.CREATE_METADATA)).thenReturn(true);
     when(datasetDao.create(testDataset)).thenReturn(testDatasetWithCreationInfo);
     DatasetId id =
         datasetService.createDataset(

--- a/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -1,15 +1,24 @@
 package bio.terra.catalog.service;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import bio.terra.catalog.config.BeanConfig;
+import bio.terra.catalog.common.StorageSystem;
 import bio.terra.catalog.datarepo.DatarepoService;
+import bio.terra.catalog.iam.SamAction;
+import bio.terra.catalog.iam.SamService;
+import bio.terra.catalog.service.dataset.Dataset;
+import bio.terra.catalog.service.dataset.DatasetDao;
 import bio.terra.catalog.service.dataset.DatasetId;
+import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
 import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,40 +29,94 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-@ContextConfiguration(classes = {DatasetService.class, BeanConfig.class})
+@ContextConfiguration(classes = {DatasetService.class})
 class DatasetServiceTest {
 
   @Autowired private DatasetService datasetService;
 
   @MockBean private DatarepoService datarepoService;
 
+  @MockBean private DatasetDao datasetDao;
+
+  @MockBean private ObjectMapper objectMapper;
+
+  @MockBean private SamService samService;
+
   private final AuthenticatedUserRequest user = mock(AuthenticatedUserRequest.class);
-
   private final DatasetId datasetId = new DatasetId(UUID.randomUUID());
+  private final Dataset dataset = new Dataset(null, StorageSystem.TERRA_DATA_REPO, null);
 
-  @Test
-  void listDatasets() {
-    var result = datasetService.listDatasets(user);
-    assertThat(result, is(notNullValue()));
+  @BeforeEach
+  public void setup() {
+    when(datasetDao.retrieve(datasetId)).thenReturn(dataset);
   }
 
   @Test
-  void deleteMetadata() {
+  void testListDatasets() {}
+
+  @Test()
+  void testDeleteMetadataWithInvalidUser() {
+    when(datasetDao.retrieve(datasetId)).thenReturn(dataset);
+    assertThrows(UnauthorizedException.class, () -> datasetService.deleteMetadata(user, datasetId));
+  }
+
+  @Test()
+  void testDeleteMetadata() {
+    when(samService.hasAction(user, SamAction.DELETE_ANY_METADATA)).thenReturn(true);
     datasetService.deleteMetadata(user, datasetId);
+    verify(datasetDao).delete(dataset);
   }
 
   @Test
-  void getMetadata() {
+  void testGetMetadataWithInvalidUser() {
+    when(datasetDao.retrieve(datasetId)).thenReturn(dataset);
+    assertThrows(UnauthorizedException.class, () -> datasetService.getMetadata(user, datasetId));
+  }
+
+  @Test
+  void testGetMetadata() {
+    when(samService.hasAction(user, SamAction.READ_ANY_METADATA)).thenReturn(true);
     datasetService.getMetadata(user, datasetId);
+    verify(datasetDao).retrieve(datasetId);
   }
 
   @Test
-  void updateMetadata() {
-    datasetService.updateMetadata(user, datasetId, "test");
+  void testUpdateMetadataWithInvalidUser() {
+    when(datasetDao.retrieve(datasetId)).thenReturn(dataset);
+    assertThrows(
+        UnauthorizedException.class, () -> datasetService.updateMetadata(user, datasetId, "test"));
   }
 
   @Test
-  void createDataset() {
+  void testUpdateMetadata() {
+    String metadata = "test metadata";
+    when(samService.hasAction(user, SamAction.UPDATE_ANY_METADATA)).thenReturn(true);
+    datasetService.updateMetadata(user, datasetId, metadata);
+    verify(datasetDao).update(dataset.withMetadata(metadata));
+  }
 
+  @Test
+  void testCreateDatasetWithInvalidUser() {
+    assertThrows(
+        UnauthorizedException.class,
+        () -> datasetService.createDataset(user, StorageSystem.TERRA_DATA_REPO, null, null));
+  }
+
+  @Test
+  void testCreateDataset() {
+    String metadata = "test metadata";
+    String storageSourceId = "testSource";
+    Dataset testDataset = new Dataset(storageSourceId, StorageSystem.TERRA_DATA_REPO, metadata);
+    Dataset testDatasetWithCreationInfo =
+        new Dataset(
+            datasetId, storageSourceId, StorageSystem.TERRA_DATA_REPO, metadata, Instant.now());
+
+    when(samService.hasAction(user, SamAction.UPDATE_ANY_METADATA)).thenReturn(true);
+    when(datasetDao.create(testDataset)).thenReturn(testDatasetWithCreationInfo);
+    DatasetId id =
+        datasetService.createDataset(
+            user, StorageSystem.TERRA_DATA_REPO, storageSourceId, metadata);
+    verify(datasetDao).create(testDataset);
+    assertEquals(id, datasetId);
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name = 'terra-data-catalog'
 include('service', 'client', 'integration')
 
-gradle.ext.releaseVersion = '0.23.0'
+gradle.ext.releaseVersion = '0.24.0'


### PR DESCRIPTION
Add support for CRUD dataset metadata (aka catalog entry) API endpoints.

The existing endpoint `/api/v1/datasets` has four new forms:

- POST `/api/v1/datasets` - creates a new dataset entry in the catalog. The caller provides a JSON body with the storage system, storage ID and catalog entry data. The endpoint returns the catalog ID of the newly created entry.
- GET `/api/v1/datasets/{id}` - return the catalog entry for the dataset
- PUT `/api/v1/datasets/{id}` - replace the catalog entry for the dataset
- DELETE `/api/v1/datasets/{id}` - delete the catalog entry for the dataset

These endpoints check that the calling user has the correct permission in the storage system (currently only TDR) or in SAM for the requested operation.

Note that integration tests are not part of this PR.