### PR TITLE
QA-1765: Add configs to enable publishing of perf test results to BigQuery.

### DIFF
--- a/.github/actions/checkout-helm-versions/action.yml
+++ b/.github/actions/checkout-helm-versions/action.yml
@@ -1,0 +1,39 @@
+# This action supports helmVersions reporting in the TestRunner BigQuery schema. For example,
+# https://console.cloud.google.com/bigquery?cloudshell=false&project=terra-kernel-k8s&ws=!1m10!1m4!4m3!1sterra-kernel-k8s!2ssimple_stream_dataset!3ssimple_streamtable!1m4!4m3!1sterra-kernel-k8s!2ssimple_stream_dataset!3sSUMMARY_testRun
+name: 'checkout-helm-versions'
+description: 'Action to do a sparse checkout of environments and versions directories from https://github.com/broadinstitute/terra-helmfile/'
+author: 'ichengchang'
+inputs:
+  repository:
+    description: 'terra-helmfile repo'
+    required: false
+    default: 'broadinstitute/terra-helmfile'
+  ref:
+    description: 'The branch, tag or SHA to checkout'
+    required: false
+    default: 'master'
+  token:
+    description: 'Access token used to fetch the repository'
+    required: true
+  path:
+    description: 'Relative path under $GITHUB_WORKSPACE to place the checkout directories'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Sparse checkout https://github.com/broadinstitute/terra-helmfile/
+      id: sparse-checkout
+      run: |
+        mkdir -p ${{ inputs.path }}
+        cd ${{ inputs.path }}
+        git init
+        git remote add origin https://${{ inputs.token }}@github.com/${{ inputs.repository }}
+        git fetch --all --quiet
+        git config core.sparseCheckout true
+        if [ -f .git/info/sparse-checkout ]; then
+          rm .git/info/sparse-checkout
+        fi
+        echo "environments/" >> .git/info/sparse-checkout
+        echo "versions/" >> .git/info/sparse-checkout
+        git checkout ${{ inputs.ref }}
+      shell: bash

--- a/.github/workflows/run-perf-tests-and-publish.yml
+++ b/.github/workflows/run-perf-tests-and-publish.yml
@@ -82,4 +82,4 @@ jobs:
           cd integration
           ../gradlew --build-cache :integration:runTest --scan --args="suites/FullPerf.json build/reports"
           echo "Upload test results to Google Bucket"
-          ./gradlew :integration:uploadResults --args="CompressDirectoryToTerraKernelK8S.json build/reports"
+          ../gradlew :integration:uploadResults --args="CompressDirectoryToTerraKernelK8S.json build/reports"

--- a/.github/workflows/run-perf-tests-and-publish.yml
+++ b/.github/workflows/run-perf-tests-and-publish.yml
@@ -9,15 +9,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      # Sparse check out terra-helmfile repo version directories
-      - uses: ./.github/actions/checkout-helm-versions
-        with:
-          repository: broadinstitute/terra-helmfile
-          ref: master
-          token: ${{ secrets.BROADBOT_TOKEN }}
-          path: integration/terra-helmfile
-
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
@@ -65,6 +56,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      # Sparse check out terra-helmfile repo version directories
+      - uses: ./.github/actions/checkout-helm-versions
+        with:
+          repository: broadinstitute/terra-helmfile
+          ref: master
+          token: ${{ secrets.BROADBOT_TOKEN }}
+          path: integration/terra-helmfile
+
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/run-perf-tests-and-publish.yml
+++ b/.github/workflows/run-perf-tests-and-publish.yml
@@ -1,0 +1,85 @@
+name: Publish Test Results
+
+on:
+  push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Sparse check out terra-helmfile repo version directories
+      - uses: ./.github/actions/checkout-helm-versions
+        with:
+          repository: broadinstitute/terra-helmfile
+          ref: master
+          token: ${{ secrets.BROADBOT_TOKEN }}
+          path: integration/terra-helmfile
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Gradle build service
+        run: ./gradlew --build-cache :service:build -x test
+
+  jib:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Construct docker image name and tag
+        id: image-name
+        run: |
+          GITHUB_REPO=$(basename ${{ github.repository }})
+          GIT_SHORT_HASH=$(git rev-parse --short HEAD)
+          echo ::set-output name=name::${GITHUB_REPO}:${GIT_SHORT_HASH}
+
+      - name: Build image locally with jib
+        run: |
+          ./gradlew --build-cache :service:jibDockerBuild \
+            --image=${{ steps.image-name.outputs.name }} \
+            -Djib.console=plain
+
+      - name: Run Trivy vulnerability scanner
+        uses: broadinstitute/dsp-appsec-trivy-action@v1
+        with:
+          image: ${{ steps.image-name.outputs.name }}
+
+  test-runner:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Render GitHub Secrets
+        run: |
+          echo "${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}" | base64 -d > "integration/src/main/resources/rendered/user-delegated-sa.json"
+          echo "${{ secrets.PERF_TESTRUNNER_ACCOUNT_B64 }}" | base64 -d > "integration/src/main/resources/rendered/testrunner-sa.json"
+
+      - name: Run perf test suite
+        run: |
+          cd integration
+          ../gradlew --build-cache :integration:runTest --scan --args="suites/FullPerf.json build/reports"
+          echo "Upload test results to Google Bucket"
+          ./gradlew :integration:uploadResults --args="CompressDirectoryToTerraKernelK8S.json build/reports"

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -3,7 +3,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 plugins {
     id 'bio.terra.catalog.java-application-conventions'
     id 'io.spring.dependency-management'
-    id 'bio.terra.test-runner-plugin'
+    id 'bio.terra.test-runner-plugin' version '0.1.3-SNAPSHOT'
 }
 
 dependencyManagement {
@@ -21,7 +21,7 @@ dependencies {
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.4.0'
 
     // Terra Test Runner Library
-    implementation 'bio.terra:terra-test-runner:0.1.1-SNAPSHOT'
+    implementation 'bio.terra:terra-test-runner:0.1.3-SNAPSHOT'
 
     // Requires client library
     implementation project(':client')

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -3,7 +3,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 plugins {
     id 'bio.terra.catalog.java-application-conventions'
     id 'io.spring.dependency-management'
-    id 'bio.terra.test-runner-plugin' version '0.1.3-SNAPSHOT'
+    id 'bio.terra.test-runner-plugin'
 }
 
 dependencyManagement {

--- a/integration/src/main/resources/servers/catalog-perf.json
+++ b/integration/src/main/resources/servers/catalog-perf.json
@@ -18,5 +18,24 @@
   "testRunnerServiceAccountFile": "testrunner-sa.json",
 
   "skipDeployment": true,
-  "skipKubernetes": true
+  "skipKubernetes": true,
+
+  "versionScripts": [
+    {
+      "name": "ReadFromTerraHelmfileRepo",
+      "description": "Version from https://github.com/broadinstitute/terra-helmfile",
+      "parametersMap": {
+        "app-name": "catalog",
+        "base-file-path": "terra-helmfile/versions/app/dev.yaml",
+        "override-file-path": "terra-helmfile/environments/live/perf.yaml"
+      }
+    },
+    {
+      "name": "ReadFromGitCommitLog",
+      "description": "Hash of git branch from Git Commit Log",
+      "parametersMap": {
+        "git-dir": "../.git"
+      }
+    }
+  ]
 }

--- a/integration/src/main/resources/serviceaccounts/testrunner-sa.json
+++ b/integration/src/main/resources/serviceaccounts/testrunner-sa.json
@@ -1,5 +1,5 @@
 {
-  "name": "testrunner-perf@terra-kernel-k8s.iam.gserviceaccount.com",
+  "name": "testrunner-perf@broad-dsde-perf.iam.gserviceaccount.com",
   "jsonKeyFilename": "testrunner-sa.json",
   "jsonKeyDirectoryPath": "src/main/resources/rendered"
 }

--- a/integration/src/main/resources/uploadlists/CompressDirectoryToTerraKernelK8S.json
+++ b/integration/src/main/resources/uploadlists/CompressDirectoryToTerraKernelK8S.json
@@ -1,0 +1,14 @@
+{
+  "name": "CompressDirectoryToTerraKernelK8S",
+  "description": "Compress results directory to the terra-kernel-k8s-testrunner-results bucket",
+  "uploaderServiceAccountFile": "testrunner-sa.json",
+  "uploadScripts": [
+    {
+      "name": "CompressDirectoryToBucket",
+      "description": "Save the compressed results directory to a bucket.",
+      "parametersMap": {
+        "bucket-path": "gs://terra-kernel-k8s-testrunner-results"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is an example workflow showing what configs are needed to enable publishing test runner results to BigQuery.

DO NOT MERGE! Use this as an example to modify existing nightly tests.