### PR TITLE
DC-158: Add warning in OpenApi description

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -52,7 +52,10 @@ paths:
           $ref: '#/components/responses/ServerError'
     post:
       tags: [ datasets ]
-      description: Create a new dataset
+      description: |
+        ⚠️ Do not add sensitive data. All catalog entries are publicly accessible to all Terra users ⚠️
+      
+        Create a new dataset
       operationId: createDataset
       requestBody:
         content:
@@ -89,7 +92,10 @@ paths:
           $ref: '#/components/responses/ServerError'
     put:
       tags: [ datasets ]
-      description: Update the catalog entry for a dataset
+      description: |
+        ⚠️ Do not add sensitive data. All catalog entries are publicly accessible to all Terra users ⚠️
+        
+        Update the catalog entry for a dataset
       operationId: updateDataset
       parameters:
         - $ref: '#/components/parameters/Id'

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -1,12 +1,15 @@
 openapi: 3.0.3
 info:
   title: Terra Data Catalog
-  description: An indexed catalog of data for use in Terra
+  description: |
+    An indexed catalog of data for use in Terra.
+
+    ⚠️ Do not add sensitive data. All catalog entries are publicly accessible to all Terra users ⚠️
   version: 0.0.1
 paths:
   /status:
     get:
-      summary: Check status of the service.
+      summary: Check status of the service
       tags: [ public ]
       operationId: getStatus
       security: [ ]
@@ -20,7 +23,7 @@ paths:
 
   /version:
     get:
-      summary: Get version info of the deployed service.
+      summary: Get version info of the deployed service
       tags: [ public ]
       operationId: getVersion
       security: [ ]
@@ -38,7 +41,7 @@ paths:
 
   /api/v1/datasets:
     get:
-      summary: Lists the available catalog datasets.
+      summary: Lists the available catalog datasets
       tags: [ datasets ]
       operationId: listDatasets
       responses:
@@ -51,11 +54,10 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
     post:
+      summary: Create a new dataset
       tags: [ datasets ]
       description: |
         ⚠️ Do not add sensitive data. All catalog entries are publicly accessible to all Terra users ⚠️
-      
-        Create a new dataset
       operationId: createDataset
       requestBody:
         content:
@@ -91,11 +93,10 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
     put:
+      summary: Update the catalog entry for a dataset
       tags: [ datasets ]
       description: |
         ⚠️ Do not add sensitive data. All catalog entries are publicly accessible to all Terra users ⚠️
-        
-        Update the catalog entry for a dataset
       operationId: updateDataset
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -123,8 +124,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
     delete:
+      summary: Delete the catalog entry for a dataset
       tags: [ datasets ]
-      description: Delete the catalog entry for a dataset
       operationId: deleteDataset
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -255,6 +256,8 @@ components:
           type: string
 
     CreateDatasetRequest:
+      description: |
+        ⚠️ Do not add sensitive data. All catalog entries are publicly accessible to all Terra users ⚠️
       type: object
       properties:
         storageSystem:


### PR DESCRIPTION
To meet the requirements for SC11 - Authorization Domains, we need to include a warning that all entries will be public to Terra users.