### PR TITLE
DC-289: fix issue with TDR permissions in catalog

### DIFF
--- a/service/src/main/java/bio/terra/catalog/app/App.java
+++ b/service/src/main/java/bio/terra/catalog/app/App.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -13,9 +12,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
     exclude = {
       // We don't make use of DataSource in this application, so exclude it from scanning.
       DataSourceAutoConfiguration.class,
-    })
-@ComponentScan(
-    basePackages = {
+    },
+    scanBasePackages = {
       // Scan for logging-related components & configs
       "bio.terra.common.logging",
       // Scan for Liquibase migration components & configs

--- a/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
+++ b/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
@@ -23,13 +23,17 @@ import org.springframework.stereotype.Component;
 public class DatarepoService {
   private static final Logger logger = LoggerFactory.getLogger(DatarepoService.class);
   public static final String ADMIN_ROLE_NAME = "admin";
-  public static final String CUSTODIAN_ROLE_NAME = "custodian";
+  public static final String STEWARD_ROLE_NAME = "steward";
   public static final String READER_ROLE_NAME = "reader";
   public static final String DISCOVERER_ROLE_NAME = "discoverer";
 
-  private static final List<String> OWNER_ROLES = List.of(ADMIN_ROLE_NAME, CUSTODIAN_ROLE_NAME);
+  private static final List<String> OWNER_ROLES = List.of(ADMIN_ROLE_NAME, STEWARD_ROLE_NAME);
   private static final List<String> READER_ROLES =
-      List.of(ADMIN_ROLE_NAME, CUSTODIAN_ROLE_NAME, READER_ROLE_NAME, DISCOVERER_ROLE_NAME);
+      List.of(ADMIN_ROLE_NAME, STEWARD_ROLE_NAME, READER_ROLE_NAME, DISCOVERER_ROLE_NAME);
+
+  // This is the maximum number of datasets returned. If we have more than 1000 datasets in TDR
+  // that are in the catalog, this number will need to be increased.
+  private static final int MAX_DATASETS = 1000;
 
   private final DatarepoConfiguration datarepoConfig;
   private final Client commonHttpClient;
@@ -43,7 +47,7 @@ public class DatarepoService {
   public Map<String, List<String>> getSnapshotIdsAndRoles(AuthenticatedUserRequest user) {
     try {
       return snapshotsApi(user)
-          .enumerateSnapshots(null, null, null, null, null, null, null)
+          .enumerateSnapshots(null, MAX_DATASETS, null, null, null, null, null)
           .getRoleMap();
     } catch (ApiException e) {
       throw new DatarepoException("Enumerate snapshots failed", e);

--- a/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
+++ b/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
@@ -31,8 +31,8 @@ public class DatarepoService {
   private static final List<String> READER_ROLES =
       List.of(ADMIN_ROLE_NAME, STEWARD_ROLE_NAME, READER_ROLE_NAME, DISCOVERER_ROLE_NAME);
 
-  // This is the maximum number of datasets returned. If we have more than 1000 datasets in TDR
-  // that are in the catalog, this number will need to be increased.
+  // This is the maximum number of datasets returned. If we have more than this number of datasets
+  // in TDR that are in the catalog, this number will need to be increased.
   private static final int MAX_DATASETS = 1000;
 
   private final DatarepoConfiguration datarepoConfig;

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -48,12 +48,6 @@ catalog:
     # Default value that's overridden by Helm.
     domain-name: localhost:8080
 
-  job:
-    max-threads: 4
-    polling-interval-seconds: 1
-    resource-id: mc-terra-data-catalog
-    timeout-seconds: 1800
-
   status-check:
     enabled: true
     polling-interval-seconds: 60

--- a/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
@@ -78,7 +78,7 @@ class DatarepoServiceTest {
   void userHasActionOwner() throws Exception {
     var id = UUID.randomUUID();
     when(snapshotsApi.retrieveUserSnapshotRoles(id))
-        .thenReturn(List.of(DatarepoService.ADMIN_ROLE_NAME));
+        .thenReturn(List.of(DatarepoService.STEWARD_ROLE_NAME));
     assertTrue(datarepoService.userHasAction(user, id.toString(), SamAction.CREATE_METADATA));
   }
 


### PR DESCRIPTION
Fix issue where a user who's been granted admin access to a snapshot wouldn't be able to create a catalog entry

Other minor cleanups

- support up to 1000 snapshots from TDR
- merge `ComponentScan` annotation with `SpringBootApplication` annotation
- remove unused `job` config from `application.yml`