### PR TITLE
DC-314: Bump version of bumper to 0.0.6

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,7 +11,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.4
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
         id: tag
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}


### PR DESCRIPTION
This should fix the issues we've been seeing with the bumper in our actions. It includes the changes from https://github.com/DataBiosphere/github-actions/pull/32