### PR TITLE
A script to set up a proxy to the catalog postgres database.

### DIFF
--- a/scripts/db_connect.sh
+++ b/scripts/db_connect.sh
@@ -3,7 +3,7 @@
 # This script requires google's cloud_sql_proxy on your PATH. One way to set this up:
 # $ brew cask install google-cloud-sdk
 # $ gcloud components install cloud_sql_proxy
-# $ PATH=$PATH:/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin/
+# $ PATH="$PATH:/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin"
 # OR
 # $ ln -s /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin/cloud_sql_proxy /usr/local/bin/cloud_sql_proxy
 #

--- a/scripts/db_connect.sh
+++ b/scripts/db_connect.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# This script requires google's cloud_sql_proxy on your PATH. One way to set this up:
+# $ brew cask install google-cloud-sdk
+# $ gcloud components install cloud_sql_proxy
+# $ PATH=$PATH:/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin/
+#
+# Use this script to connect to cloud Postgres for a specific Catalog instance.
+# For example, to connect to the dev catalog database, run:
+# $ ENV=dev ./db-connect.sh
+#
+# The proxy will continue to run until you quit it using ^C.
+#
+# The default port used is 5431, to avoid conflicting with a locally running postgres which
+# defaults to port 5432. Use the environment variable PORT to override this setting.
+
+: "${ENV:?}"
+PORT=${PORT:-5431}
+
+VAULT_PATH="secret/dsde/terra/kernel/${ENV}/${ENV}/catalog/postgres"
+
+INSTANCE_DATA=$(vault read -field=data -format=json "${VAULT_PATH}/instance")
+NAME=$(echo "${INSTANCE_DATA}" | jq -r '.name')
+PROJECT=$(echo "${INSTANCE_DATA}" | jq -r '.project')
+REGION=$(echo "${INSTANCE_DATA}" | jq -r '.region')
+
+DB_DATA=$(vault read -field=data -format=json "${VAULT_PATH}/db-creds")
+DB=$(echo "${DB_DATA}" | jq -r '.db')
+USER=$(echo "${DB_DATA}" | jq -r '.username')
+PASSWORD=$(echo "${DB_DATA}" | jq -r '.password')
+
+echo "Starting a proxy for $ENV. Connection: jdbc:postgresql://localhost:$PORT/$DB?user=$USER&password=$PASSWORD"
+
+cloud_sql_proxy -instances="${PROJECT}:${REGION}:${NAME}=tcp:${PORT}"

--- a/scripts/db_connect.sh
+++ b/scripts/db_connect.sh
@@ -19,7 +19,7 @@
 : "${ENV:?}"
 PORT=${PORT:-5431}
 
-VAULT_PATH=secret/dsde/terra/kernel/${ENV}/${ENV}/catalog/postgres
+VAULT_PATH="secret/dsde/terra/kernel/${ENV}/${ENV}/catalog/postgres"
 
 INSTANCE=$(vault read -field=data -format=json "${VAULT_PATH}/instance" |
            jq -r '"\(.project):\(.region):\(.name)"')

--- a/scripts/hca/README.md
+++ b/scripts/hca/README.md
@@ -12,7 +12,7 @@ pip install black tqdm
 3. Generate and save an `AUTH_TOKEN` which is required to make API requests:
 
 ```sh
-AUTH_TOKEN="Authorization: Bearer $(gcloud auth application-default print-access-token)"
+export AUTH_TOKEN="Authorization: Bearer $(gcloud auth application-default print-access-token)"
 ```
 
 4. Extract the HCA project and snapshot data as JSON files. `create-hca-collection.py` combines the two to create a collection file.
@@ -27,6 +27,9 @@ python3 create-hca-collection.py
 
 ```sh
 source .env/bin/activate
+export USER_EMAIL=datacatalogadmin@test.firecloud.org
+# OR
+export USER_EMAIL=monster.pshapiro.dev@gmail.com
 python3 ingest-hca-collection.py
 ```
 

--- a/scripts/hca/README.md
+++ b/scripts/hca/README.md
@@ -28,8 +28,7 @@ python3 create-hca-collection.py
 ```sh
 source .env/bin/activate
 export USER_EMAIL=datacatalogadmin@test.firecloud.org
-# OR
-export USER_EMAIL=monster.pshapiro.dev@gmail.com
+# OR export your personal dev admin email address
 python3 ingest-hca-collection.py
 ```
 


### PR DESCRIPTION
This script supports running a local proxy to connect to our cloud database. When run, it prints out a JDBC URL that can be pasted into IntelliJ or other SQL IDEs to view tables, etc. Note that this connects using the admin user so it can modify data, so please use it carefully when connecting to the prod database.