### PR TITLE
[DC-298] Sl For response consistency and clarity, listDatasets should return an empty result set, rather than no result field at all, when there are no results

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -236,6 +236,7 @@ components:
 
     DatasetsListResponse:
       type: object
+      required: [result]
       properties:
         result:
           type: array

--- a/scripts/catalog-tests/.env/lib/python3.9/site-packages/pip/_vendor/packaging/__about__.py
+++ b/scripts/catalog-tests/.env/lib/python3.9/site-packages/pip/_vendor/packaging/__about__.py
@@ -1,0 +1,26 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+
+__all__ = [
+    "__title__",
+    "__summary__",
+    "__uri__",
+    "__version__",
+    "__author__",
+    "__email__",
+    "__license__",
+    "__copyright__",
+]
+
+__title__ = "packaging"
+__summary__ = "Core utilities for Python packages"
+__uri__ = "https://github.com/pypa/packaging"
+
+__version__ = "21.0"
+
+__author__ = "Donald Stufft and individual contributors"
+__email__ = "donald@stufft.io"
+
+__license__ = "BSD-2-Clause or Apache-2.0"
+__copyright__ = "2014-2019 %s" % __author__


### PR DESCRIPTION
listDatasets(), return {result:[]}, as opposed to {}.