### PR TITLE
DC-300: Update the swagger-client-id path

### DIFF
--- a/render_configs.sh
+++ b/render_configs.sh
@@ -15,7 +15,7 @@ if ! [ -x "$(command -v vault)" ]; then
 fi
 
 $VAULT_COMMAND -field=data -format=json "secret/dsde/firecloud/$ENV/common/firecloud-account.json" >"$INTEGRATION_OUTPUT_LOCATION/user-delegated-sa.json"
-$VAULT_COMMAND -field=swagger-client-id "$CATALOG_VAULT_PATH" >"$SERVICE_OUTPUT_LOCATION/swagger-client-id"
+$VAULT_COMMAND -field=swagger-client-id "$CATALOG_VAULT_PATH/swagger-client-id" >"$SERVICE_OUTPUT_LOCATION/swagger-client-id"
 
 if [ $ENV == perf ]; then
   $VAULT_COMMAND -field=key "$COMMON_VAULT_PATH/testrunner/testrunner-sa" | base64 -d > "$INTEGRATION_OUTPUT_LOCATION/testrunner-sa.json"


### PR DESCRIPTION
Previously, we had client ids which lived at the following paths:

1. `secret/dsde/terra/kernel/dev/dev/catalog/swagger-client-id`
2. `secret/dsde/terra/kernel/dev/dev/catalog`

To be consistent with other services, the client id should live at `{service}/swagger-client-id`, however we had an invalid client id at that path and a valid one at the `/catalog` path. This fixes the path issue in the `render-configs.sh` script.