### PR TITLE
DC-286: publish perf test results to QA dashboard

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -58,6 +58,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Alternative way of getting terra-helmfile repo version files
+        run: |
+          curl -H 'Authorization: token ${{ secrets.BROADBOT_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' \
+            -L https://api.github.com/repos/broadinstitute/terra-helmfile/contents/versions/app/dev.yaml \
+            --create-dirs -o "integration/terra-helmfile/versions/app/dev.yaml"
+          curl -H 'Authorization: token ${{ secrets.BROADBOT_TOKEN }}' \
+            -H 'Accept: application/vnd.github.v3.raw' \
+            -L https://api.github.com/repos/broadinstitute/terra-helmfile/contents/environments/live/perf.yaml \
+            --create-dirs -o "integration/terra-helmfile/environments/live/perf.yaml"
+
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
@@ -68,11 +80,12 @@ jobs:
       - name: Render GitHub Secrets
         run: |
           echo "${{ secrets.DEV_FIRECLOUD_ACCOUNT_B64 }}" | base64 -d > "integration/src/main/resources/rendered/user-delegated-sa.json"
-          echo "${{ secrets.PERF_TESTRUNNER_ACCOUNT_B64 }}" | base64 -d > "integration/src/main/resources/rendered/testrunner-sa.json"
+          echo "${{ secrets.PERF_TESTRUNNER_ACCOUNT_B64 }}" | base64 -d > "integration/src/main/resources/rendered/testrunner-perf.json"
 
       - name: Run perf test suite
         run: |
-          ./gradlew --build-cache :integration:runTest --scan --args="suites/FullPerf.json build/reports"
+          ./gradlew --build-cache runTest --scan --args="suites/FullPerf.json build/reports"
+          ./gradlew --build-cache uploadResults --args="CompressDirectoryToTerraKernelK8S.json build/reports"
 
       - name: Upload Test Reports
         if: always()
@@ -85,7 +98,7 @@ jobs:
     needs: [ build, jib, test-runner ]
     runs-on: ubuntu-latest
     if: always()
-    
+
     steps:
       - name: "Notify #jade-data-explorer Slack on failure"
         uses: broadinstitute/action-slack@v3.8.0

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.1'
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:3.3'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:2.6.6'
-    implementation 'bio.terra:terra-test-runner:0.0.8-SNAPSHOT'
+    implementation 'bio.terra:terra-test-runner:0.1.4-SNAPSHOT'
     // This is required due to a dependency conflict between jib and srcclr. Removing it will cause jib to fail.
     implementation 'org.apache.commons:commons-compress:1.21'
 }

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation 'com.google.auth:google-auth-library-oauth2-http:1.4.0'
 
     // Terra Test Runner Library
-    implementation 'bio.terra:terra-test-runner:0.1.1-SNAPSHOT'
+    implementation 'bio.terra:terra-test-runner:0.1.4-SNAPSHOT'
 
     // Requires client library
     implementation project(':client')

--- a/integration/src/main/resources/servers/catalog-local.json
+++ b/integration/src/main/resources/servers/catalog-local.json
@@ -5,7 +5,7 @@
   "catalogUri": "http://localhost:8080",
   "datarepoUri": "https://jade.datarepo-dev.broadinstitute.org/",
 
-  "testRunnerServiceAccountFile": "delegate-user-sa.json",
+  "testRunnerServiceAccountFile": "testrunner-perf.json",
 
   "skipDeployment": true,
   "skipKubernetes": true

--- a/integration/src/main/resources/servers/catalog-perf.json
+++ b/integration/src/main/resources/servers/catalog-perf.json
@@ -16,8 +16,27 @@
     "apiComponentLabel":  "catalog"
   },
   "deploymentScript": {},
-  "testRunnerServiceAccountFile": "testrunner-sa.json",
+  "testRunnerServiceAccountFile": "testrunner-perf.json",
 
   "skipDeployment": true,
-  "skipKubernetes": true
+  "skipKubernetes": true,
+
+  "versionScripts": [
+    {
+      "name": "ReadFromTerraHelmfileRepo",
+      "description": "Version from https://github.com/broadinstitute/terra-helmfile",
+      "parametersMap": {
+        "app-name": "catalog",
+        "base-file-path": "terra-helmfile/versions/app/dev.yaml",
+        "override-file-path": "terra-helmfile/environments/live/perf.yaml"
+      }
+    },
+    {
+      "name": "ReadFromGitCommitLog",
+      "description": "Hash of git branch from Git Commit Log",
+      "parametersMap": {
+        "git-dir": "../.git"
+      }
+    }
+  ]
 }

--- a/integration/src/main/resources/serviceaccounts/testrunner-perf.json
+++ b/integration/src/main/resources/serviceaccounts/testrunner-perf.json
@@ -1,0 +1,5 @@
+{
+  "name": "testrunner-perf@broad-dsde-perf.iam.gserviceaccount.com",
+  "jsonKeyFilename": "testrunner-perf.json",
+  "jsonKeyDirectoryPath": "src/main/resources/rendered"
+}

--- a/integration/src/main/resources/serviceaccounts/testrunner-sa.json
+++ b/integration/src/main/resources/serviceaccounts/testrunner-sa.json
@@ -1,5 +1,0 @@
-{
-  "name": "testrunner-perf@terra-kernel-k8s.iam.gserviceaccount.com",
-  "jsonKeyFilename": "testrunner-sa.json",
-  "jsonKeyDirectoryPath": "src/main/resources/rendered"
-}

--- a/integration/src/main/resources/uploadlists/CompressDirectoryToTerraKernelK8S.json
+++ b/integration/src/main/resources/uploadlists/CompressDirectoryToTerraKernelK8S.json
@@ -1,0 +1,14 @@
+{
+  "name": "CompressDirectoryToTerraKernelK8S",
+  "description": "Compress results directory to the terra-kernel-k8s-testrunner-results bucket",
+  "uploaderServiceAccountFile": "testrunner-perf.json",
+  "uploadScripts": [
+    {
+      "name": "CompressDirectoryToBucket",
+      "description": "Save the compressed results directory to a bucket.",
+      "parametersMap": {
+        "bucket-path": "gs://terra-kernel-k8s-testrunner-results"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This migrates changes from QA-1765 branch to current code base. This adds a command to the nightly builds that uploads test results into  GS bucket.