### PR TITLE
DC-319: Update perf catalog tests to run using dev TDR

### DIFF
--- a/integration/src/main/resources/configs/perf/SnapshotDatasetOperations.json
+++ b/integration/src/main/resources/configs/perf/SnapshotDatasetOperations.json
@@ -7,7 +7,7 @@
   "testScripts": [
     {
       "name": "SnapshotDatasetOperations",
-      "numberOfUserJourneyThreadsToRun": 10,
+      "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 2,
       "expectedTimeForEach": 5,
       "expectedTimeForEachUnit": "SECONDS"

--- a/integration/src/main/resources/configs/perf/SnapshotDatasetOperations.json
+++ b/integration/src/main/resources/configs/perf/SnapshotDatasetOperations.json
@@ -13,5 +13,5 @@
       "expectedTimeForEachUnit": "SECONDS"
     }
   ],
-  "testUserFiles": [ "user.json" ]
+  "testUserFiles": [ "admin.json" ]
 }

--- a/integration/src/main/resources/servers/catalog-perf.json
+++ b/integration/src/main/resources/servers/catalog-perf.json
@@ -3,7 +3,7 @@
   "description": "Catalog Performance Testing Environment",
 
   "catalogUri": "https://catalog.dsde-perf.broadinstitute.org/",
-  "datarepoUri": "https://jade-perf.datarepo-perf.broadinstitute.org/",
+  "datarepoUri": "https://jade.datarepo-dev.broadinstitute.org/",
 
   "cluster": {
     "clusterName": "terra-perf",


### PR DESCRIPTION
Update the perf catalog tests to use dev TDR instead of perf TDR. The perf TDR environment isn't stable and can't currently be used for catalog tests.