### PR TITLE
DC-364: Ensure nightly scheduled test has a default env

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -17,7 +17,7 @@ on:
     - cron: "0 6 * * *" # runs at 6 AM UTC, 1 AM EST.
 
 env:
-  TEST_ENV: ${{ github.event.inputs.environment }}
+  TEST_ENV: ${{ github.event.inputs.environment || perf }}
 
 jobs:
   build:


### PR DESCRIPTION
According to https://github.community/t/how-can-you-use-expressions-as-the-workflow-dispatch-input-default/141454/4 , it should be possible to provide a default if none is provided.