### PR TITLE
DC-364: Do not require jib step to publish images

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -176,7 +176,7 @@ jobs:
         run: ./gradlew --build-cache runTest --args="suites/dev/FullIntegration.json build/reports"
 
   notify-slack:
-    needs: [ build, jib, unit-tests-and-sonarqube, source-clear, integration-tests ]
+    needs: [ build, unit-tests-and-sonarqube, source-clear, integration-tests ]
     runs-on: ubuntu-latest
 
     if: failure() && github.ref == 'refs/heads/main'
@@ -195,7 +195,7 @@ jobs:
           username: 'Data Explorer GitHub Action'
 
   dispatch-tag:
-    needs: [ build, jib, unit-tests-and-sonarqube, source-clear, integration-tests ]
+    needs: [ build, unit-tests-and-sonarqube, source-clear, integration-tests ]
     runs-on: ubuntu-latest
 
     if: success() && github.ref == 'refs/heads/main'


### PR DESCRIPTION
When Trivy fails in the `jib` step it prevents the code from being tagged and the image from being created. Skip these checks when the code is merged to main.