### PR TITLE
DC-364: Revert "Ensure nightly scheduled test has a default env (#86)"

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -176,7 +176,7 @@ jobs:
         run: ./gradlew --build-cache runTest --args="suites/dev/FullIntegration.json build/reports"
 
   notify-slack:
-    needs: [ build, jib, unit-tests-and-sonarqube, source-clear, integration-tests ]
+    needs: [ build, unit-tests-and-sonarqube, source-clear, integration-tests ]
     runs-on: ubuntu-latest
 
     if: failure() && github.ref == 'refs/heads/main'
@@ -195,7 +195,7 @@ jobs:
           username: 'Data Explorer GitHub Action'
 
   dispatch-tag:
-    needs: [ build, jib, unit-tests-and-sonarqube, source-clear, integration-tests ]
+    needs: [ build, unit-tests-and-sonarqube, source-clear, integration-tests ]
     runs-on: ubuntu-latest
 
     if: success() && github.ref == 'refs/heads/main'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -17,7 +17,7 @@ on:
     - cron: "0 6 * * *" # runs at 6 AM UTC, 1 AM EST.
 
 env:
-  TEST_ENV: ${{ github.event.inputs.environment || perf }}
+  TEST_ENV: ${{ github.event.inputs.environment }}
 
 jobs:
   build:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -18,6 +18,7 @@ on:
 
 env:
   TEST_ENV: ${{ github.event.inputs.environment }}
+  TEST_DEFAULT: perf
 
 jobs:
   build:
@@ -72,6 +73,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set default test env
+        run: |
+          echo "TEST_ENV=${{ env.TEST_ENV || env.TEST_DEFAULT }}" >> $GITHUB_ENV
 
       - name: Get the helm chart versions for the perf env
         run: |

--- a/scripts/manually-run-nightly-tests.sh
+++ b/scripts/manually-run-nightly-tests.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-TOKEN=$(cat "$HOME/.github-token")
+TOKEN=$(find "$HOME" -type f -maxdepth 2 -exec grep -l "^ghp_" {} \; -quit | xargs cat)
 TEST_ENV="perf"
 
 # ensure the script always runs in the parent directory terra-data-catalog

--- a/scripts/manually-run-nightly-tests.sh
+++ b/scripts/manually-run-nightly-tests.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+TOKEN=$(cat $HOME/.github-token)
+TEST_ENV="perf"
+
+# ensure the script always runs in the parent directory terra-data-catalog
+CWD=$(dirname $(dirname $(readlink -f "$0")))
+cd $CWD
+
+# get the helm chart versions for the perf env
+curl -H "Authorization: token ${TOKEN}" \
+    -H 'Accept: application/vnd.github.v3.raw' \
+    -L https://api.github.com/repos/broadinstitute/terra-helmfile/contents/versions/app/dev.yaml \
+    --create-dirs -o "integration/src/main/resources/rendered/dev.yaml"
+curl -H "Authorization: token ${TOKEN}" \
+    -H 'Accept: application/vnd.github.v3.raw' \
+    -L https://api.github.com/repos/broadinstitute/terra-helmfile/contents/environments/live/perf.yaml \
+    --create-dirs -o "integration/src/main/resources/rendered/$TEST_ENV.yaml"
+
+# render the service account secrets
+vault read secret/dsde/firecloud/dev/common/firecloud-sa -format=json | \
+    jq -r .data.key | base64 -d > "integration/src/main/resources/rendered/user-delegated-sa.json"
+
+vault read secret/dsde/terra/kernel/perf/common/testrunner/testrunner-sa -format=json | \
+    jq -r .data.key | base64 -d > "integration/src/main/resources/rendered/testrunner-perf.json"
+
+# run the perf test suite
+./gradlew --build-cache runTest --args="suites/$TEST_ENV/FullIntegration.json build/reports"
+./gradlew --build-cache uploadResults --args="CompressDirectoryToTerraKernelK8S.json build/reports"

--- a/scripts/manually-run-nightly-tests.sh
+++ b/scripts/manually-run-nightly-tests.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 
-TOKEN=$(cat $HOME/.github-token)
+set -eu
+
+TOKEN=$(cat "$HOME/.github-token")
 TEST_ENV="perf"
 
 # ensure the script always runs in the parent directory terra-data-catalog
-CWD=$(dirname $(dirname $(readlink -f "$0")))
-cd $CWD
+CWD=$(dirname "$(dirname "$(readlink -f "$0")")")
+cd "$CWD"
 
 # get the helm chart versions for the perf env
 curl -H "Authorization: token ${TOKEN}" \


### PR DESCRIPTION
This reverts commit b5a479bfb7dd2c23150cf8b553cefec688ed742f.

The GitHub community recommendation will actually break the action. I switched to another solution proposed by @pshapiro4broad .

Also includes the fix from: https://github.com/DataBiosphere/terra-data-catalog/pull/87