### PR TITLE
DC-395: update spotless plugin and remove workaround in gradle.properties

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,16 +10,16 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.5.0'
+    implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.7.1'
     implementation 'com.felipefzdz.gradle.shellcheck:shellcheck:1.4.6'
-    implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.2.0'
-    implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.10'
-    implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.0.1'
+    implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.2.1'
+    implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.12'
+    implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.1.0'
     implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.2'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.11.RELEASE'
-    implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.1'
-    implementation 'org.sonarqube:org.sonarqube.gradle.plugin:3.3'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:2.6.6'
+    implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
+    implementation 'org.sonarqube:org.sonarqube.gradle.plugin:3.4.0.2513'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:2.7.0'
     implementation 'bio.terra:terra-test-runner:0.1.5-SNAPSHOT'
     // This is required due to a dependency conflict between jib and srcclr. Removing it will cause jib to fail.
     implementation 'org.apache.commons:commons-compress:1.21'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,1 @@
-# Required due to bug in google-java-format plugin. See https://github.com/diffplug/spotless/issues/834
-org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 org.gradle.parallel=true


### PR DESCRIPTION
Also updated many other plugin versions to the latest version.