### PR TITLE
DC-415: link to workspace support; add workspace URL to dataset metadata

### DIFF
--- a/scripts/hca/extract-hca-projects.py
+++ b/scripts/hca/extract-hca-projects.py
@@ -5,7 +5,7 @@ from urllib.request import urlopen
 from urllib.error import HTTPError
 
 # todo: refactor to use request library
-url = "https://service.azul.data.humancellatlas.org/index/projects?catalog=dcp14&size=1000&sort=projectTitle&order=desc"
+url = "https://service.azul.data.humancellatlas.org/index/projects?catalog=dcp16&size=1000&sort=projectTitle&order=desc"
 
 projects = []
 

--- a/scripts/workspace-conversion/README.md
+++ b/scripts/workspace-conversion/README.md
@@ -21,41 +21,47 @@ The request made to retrieve the workspace details is an XHR request to rawls to
 }
 ```
 
-What is shown to the user in that table is the contents in the attributes that terra-ui has determined is important to display. These values are hardcoded at 
+What is shown to the user in that table is the contents in the attributes that terra-ui has determined is important to display. These values are hardcoded at
 `{terra-ui}/src/data/workspace-cleanAttributes.js.displayLibraryAttributes`
 
 # Value mappings
 To run the conversion from workspace to dataset, here is a current mapping scheme:
 
 
-| i | Attribute | Rawls Workspace Path | Data Catalog Entry Path |
-| - | --------- | -------------------- | -------------------------- |
-| 1 | Cohort Phenotype/Indication (Disease Ontology)  | `library:diseaseOntologyLabel` | `samples.disease.0`<br>kathy: lists predefined terms, but forces them to stick with a specific vocabulary. The other phenotype field is the diseases |
-| 2 | No. of Subjects | `library:numSubjects` | `counts.donors`<br>Kathy: suggests leaving out this field because it is volatile and can easily become inaccurate |
-| 3 | Data Category | `library:dataCategory`<br>ex: "Simple Nucleotide Variation, Copy Number Variation, Expression Quantification, DNA-Methylation, Clinical phenotypes, Biosample metadata" | `dct:dataCategory`*<br>This field does not currently exist |
-| 4 | Experimental Strategy | `library:datatype`<br>ex: "Whole Exome, Genotyping Array, RNA-Seq, miRNA-Seq, Methylation Array, Protein Expression Array" | Kathy: Map this to data modality, talk to kathy about getting the mapping of terms |
-| 5 | Data Use Limitation | `library:dataUseRestriction` | `TerraDCAT_ap:hasDataUsePermission.0`<br>Not a perfect mapping, we will need to normalize "General Research Use" to "TerraCore:GeneralResearchUse", preferably using the mapping found [here](https://github.com/DataBiosphere/terra-ui/blob/dev/src/pages/library/dataBrowser-utils.js#23) under `datasetReleasePolicies` |
-| 6 | Cohort Phenotype/Indication | `library:indication`<br>ex: "Mesothelioma" | `samples.disease.0`<br>kathy: might not be useful, could consider pre-pending with source (ie: "TCGA" or "Anvil_phenotype") |
-| 7 | Cohort Name | `library:datasetName` | `dct:title` |
-| 8 | Dataset Version | `library:datasetVersion` | `dct:version` |
-| 9 | Cohort Description | `library:datasetDescription` | `dct:description` |
-| 10 | Dataset Owner | `library:datasetOwner`<br>ex: "NCI" | `TerraDCAT_ap:hasOwner`<br>`TerraDCAT_ap:hasDataCollection.0.dct:identifier`<br>If we have enough information, we can also build:<br> `TerraDCAT_AP:hasDataCollection.0.dct:publisher: National Cancer Institute`<br>`TerraDCAT_AP:hasDataCollection.0.dct:title: National Cancer Institute` |
-| 11 | Dataset Custodian | `library:datasetCustodian`<br>ex: "dbGAP" | `TerraDCAT_ap:hasCustodian`<br>`TerraDCAT_ap:hasDataCollection.0.dct:identifier`<br>Note: This conflicts with "Dataset Owner", but I dont think we have another option for where to put this. |
-| 12 | Dataset Depositor | `library:datasetDepositor` | `contributors.0.contactName`<br>`contributors.0.correspondingContributor = true` |
-| 13 | Contact Email | `library:contactEmail` | `contributors.0.email` |
-| 14 | Research Institute | `library:institute` | `contributors.0.institution`<br>`prov:wasAssociatedWith` |
-| 15 | Primary Disease Site | `library:primaryDiseaseSite`<br>ex: "Pleura" | `samples.disease.0`?<br>ex: "Brain Cancer" |
-| 16 | Project Name | `library:projectName`<br>ex: "TCGA" | `prov:wasGeneratedBy.0.TerraCore:hasAssayType.0` |
-| 17 | Genome Reference Version | `library:reference`<br>ex: "GRCh37/hg19" |  |
-| 18 | Data File Formats | `library:dataFileFormats`<br>ex: "TXT, MAF" | `files.0.dcat:mediaType`<br>`files.0.count = 0`<br>`files.0.byteSize = 0`<br>Note: No way of knowing how many files match each file format |
-| 19 | Profiling Instrument Type | `library:technology` |  |
-| 20 | Profiling Protocol | `library:profilingProtocol` |  |
-| 21 | Depth of Sequencing Coverage (Average) | `library:coverage` |  |
-| 22 | Study Design | `library:studyDesign`<br>ex: "Tumor/Normal" | `samples.disease.0`<br>Note: concat value with "Primary Disease Site"? |
-| 23 | Cell Type | `library:cellType`<br>ex: "Primary tumor cell, Whole blood" | `samples.disease.0`<br>Note: concat value with "Primary Disease Site"? |
-| 24 | Reported Ethnicity | `library:ethnicity` |  |
-| 25 | Cohort Country of Origin | `library:cohortCountry`<br>ex: "USA" |  |
-| 26 | Requires External Approval | `library:requiresExternalApproval` |  |
-| 27 | library Metadata Schema Version Number | `library:lmsvn` |  |
-| 28 | Structured Data Use Limitations Version Number | `library:dulvn` |  |
-| 29 | ORSP Conset Code | `library:orsp` | `TerraDCAT_ap:hasConsentGroup` |
+| i   | Attribute                                      | Rawls Workspace Path | Data Catalog Entry Path |
+|-----|------------------------------------------------| -------------------- | -------------------------- |
+| 1   | Cohort Phenotype/Indication (Disease Ontology) | `library:diseaseOntologyLabel` | `samples.disease.0`<br>kathy: lists predefined terms, but forces them to stick with a specific vocabulary. The other phenotype field is the diseases |
+| 2   | No. of Subjects                                | `library:numSubjects` | `counts.donors`<br>Kathy: suggests leaving out this field because it is volatile and can easily become inaccurate |
+| 3   | Data Category                                  | `library:dataCategory`<br>ex: "Simple Nucleotide Variation, Copy Number Variation, Expression Quantification, DNA-Methylation, Clinical phenotypes, Biosample metadata" | `dct:dataCategory`*<br>This field does not currently exist |
+| 4   | Experimental Strategy                          | `library:datatype`<br>ex: "Whole Exome, Genotyping Array, RNA-Seq, miRNA-Seq, Methylation Array, Protein Expression Array" | Kathy: Map this to data modality, talk to kathy about getting the mapping of terms |
+| 5   | Data Use Limitation                            | `library:dataUseRestriction` | `TerraDCAT_ap:hasDataUsePermission.0`<br>Not a perfect mapping, we will need to normalize "General Research Use" to "TerraCore:GeneralResearchUse", preferably using the mapping found [here](https://github.com/DataBiosphere/terra-ui/blob/dev/src/pages/library/dataBrowser-utils.js#23) under `datasetReleasePolicies` |
+| 6   | Cohort Phenotype/Indication                    | `library:indication`<br>ex: "Mesothelioma" | `samples.disease.0`<br>kathy: might not be useful, could consider pre-pending with source (ie: "TCGA" or "Anvil_phenotype") |
+| 7   | Cohort Name                                    | `library:datasetName` | `dct:title` |
+| 8   | Dataset Version                                | `library:datasetVersion` | `dct:version` |
+| 9   | Cohort Description                             | `library:datasetDescription` | `dct:description` |
+| 10  | Dataset Owner                                  | `library:datasetOwner`<br>ex: "NCI" | `TerraDCAT_ap:hasOwner`<br>`TerraDCAT_ap:hasDataCollection.0.dct:identifier`<br>If we have enough information, we can also build:<br> `TerraDCAT_AP:hasDataCollection.0.dct:publisher: National Cancer Institute`<br>`TerraDCAT_AP:hasDataCollection.0.dct:title: National Cancer Institute` |
+| 11  | Dataset Custodian                              | `library:datasetCustodian`<br>ex: "dbGAP" | `TerraDCAT_ap:hasCustodian`<br>`TerraDCAT_ap:hasDataCollection.0.dct:identifier`<br>Note: This conflicts with "Dataset Owner", but I dont think we have another option for where to put this. |
+| 12  | Dataset Depositor                              | `library:datasetDepositor` | `contributors.0.contactName`<br>`contributors.0.correspondingContributor = true` |
+| 13  | Contact Email                                  | `library:contactEmail` | `contributors.0.email` |
+| 14  | Research Institute                             | `library:institute` | `contributors.0.institution`<br>`prov:wasAssociatedWith` |
+| 15  | Primary Disease Site                           | `library:primaryDiseaseSite`<br>ex: "Pleura" | `samples.disease.0`?<br>ex: "Brain Cancer" |
+| 16  | Project Name                                   | `library:projectName`<br>ex: "TCGA" | `prov:wasGeneratedBy.0.TerraCore:hasAssayType.0` |
+| 17  | Genome Reference Version                       | `library:reference`<br>ex: "GRCh37/hg19" |  |
+| 18  | Data File Formats                              | `library:dataFileFormats`<br>ex: "TXT, MAF" | `files.0.dcat:mediaType`<br>`files.0.count = 0`<br>`files.0.byteSize = 0`<br>Note: No way of knowing how many files match each file format |
+| 19  | Profiling Instrument Type                      | `library:technology` |  |
+| 20  | Profiling Protocol                             | `library:profilingProtocol` |  |
+| 21  | Depth of Sequencing Coverage (Average)         | `library:coverage` |  |
+| 22  | Study Design                                   | `library:studyDesign`<br>ex: "Tumor/Normal" | `samples.disease.0`<br>Note: concat value with "Primary Disease Site"? |
+| 23  | Cell Type                                      | `library:cellType`<br>ex: "Primary tumor cell, Whole blood" | `samples.disease.0`<br>Note: concat value with "Primary Disease Site"? |
+| 24  | Reported Ethnicity                             | `library:ethnicity` |  |
+| 25  | Cohort Country of Origin                       | `library:cohortCountry`<br>ex: "USA" |  |
+| 26  | Requires External Approval                     | `library:requiresExternalApproval` |  |
+| 27  | library Metadata Schema Version Number         | `library:lmsvn` |  |
+| 28  | Structured Data Use Limitations Version Number | `library:dulvn` |  |
+| 29  | ORSP Conset Code                               | `library:orsp` | `TerraDCAT_ap:hasConsentGroup` |
+
+Other Generated attributes
+
+| Attribute | Data Catalog Entry Path | Source |
+| --- |--------------------------------| --- |
+| Workspace URL | dcat:accessURL | created using project and workspace name |

--- a/scripts/workspace-conversion/workspace-to-dataset.py
+++ b/scripts/workspace-conversion/workspace-to-dataset.py
@@ -270,10 +270,8 @@ def get_workspace_files(wsAttributes):
 def access_url(workspace):
     p = re.compile("rawls.dsde-(\\w+)")
     env = p.search(urlRoot).group(1)
-    if env == "prod":
-        terra_url = "https://app.terra.bio"
-    else:
-        terra_url = f"https://bvdp-saturn-{env}.appspot.com"
+    terra_url = "https://app.terra.bio" if env == "prod"
+    else f"https://bvdp-saturn-{env}.appspot.com"
 
     w = workspace["workspace"]
 

--- a/scripts/workspace-conversion/workspace-to-dataset.py
+++ b/scripts/workspace-conversion/workspace-to-dataset.py
@@ -348,13 +348,13 @@ def generate_catalog_metadata(workspace, bucket):
         "prov:wasGeneratedBy": get_workspace_generated(wsAttributes),
         "files": get_workspace_files(wsAttributes),
         "TerraDCAT_ap:hasConsentGroup": wsAttributes.pop("library:orsp", None),
-        # "storage": [
-        #     {
-        #         bucket["locationType"]: bucket["location"],
-        #         "cloudPlatform": "gcp",
-        #         "cloudResource": "bucket",
-        #     }
-        # ],
+        "storage": [
+            {
+                bucket["locationType"]: bucket["location"],
+                "cloudPlatform": "gcp",
+                "cloudResource": "bucket",
+            }
+        ],
         "workspaces": {"legacy": workspace},
     }
 

--- a/scripts/workspace-conversion/workspace-to-dataset.py
+++ b/scripts/workspace-conversion/workspace-to-dataset.py
@@ -275,7 +275,7 @@ def access_url(workspace):
     else:
         terra_url = f"https://bvdp-saturn-{env}.appspot.com"
 
-    w = workspace['workspace']
+    w = workspace["workspace"]
 
     return f"{terra_url}/#workspaces/{w['namespace']}/{w['name']}"
 

--- a/scripts/workspace-conversion/workspace-to-dataset.py
+++ b/scripts/workspace-conversion/workspace-to-dataset.py
@@ -16,24 +16,22 @@
 #
 # Run:
 #   `python3 workspace-to-dataset.py`
-#   `export GCLOUD_USER={your-email}; export WORKSPACE_NAMESPACE={workspace-namespace}; export WORKSPACE_NAME={workspace-name}; python3 workspace-to-dataset.py`
+#   `WORKSPACE_NAMESPACE={workspace-namespace} WORKSPACE_NAME={workspace-name} python3 workspace-to-dataset.py`
 #
 # Environment Variables:
-#   GCLOUD_USER: user account email
 #   WORKSPACE_NAMESPACE: workspace namespace for the rawls query
 #   WORKSPACE_NAME: workspace name for the rawls query
-#   RAWLS_URL: url for rawls. Default set to rawls-prod
-#   TERRA_URL: url for terra ui. Default set to staging. Used to output demo link.
+#   GCLOUD_USER: user account email; default is `datacatalogadmin@test.firecloud.org`
+#   ENV: terra environment to get workspace data from; default is `prod`
 # ------------------------------------------------------------------------------
 import json
 import os, subprocess
-import re
 
 import requests
 import itertools
 
-urlRoot = os.environ.get("RAWLS_URL") or "https://rawls.dsde-prod.broadinstitute.org"
-urlWorkspace = f"{urlRoot}/api/workspaces"
+env = os.environ.get("ENV") or "prod"
+urlWorkspace = f"https://rawls.dsde-{env}.broadinstitute.org/api/workspaces"
 workspaceNamespace = os.environ.get("WORKSPACE_NAMESPACE")
 workspaceName = os.environ.get("WORKSPACE_NAME")
 user = os.environ.get("GCLOUD_USER") or "datacatalogadmin@test.firecloud.org"
@@ -268,10 +266,11 @@ def get_workspace_files(wsAttributes):
 
 
 def access_url(workspace):
-    p = re.compile("rawls.dsde-(\\w+)")
-    env = p.search(urlRoot).group(1)
-    terra_url = "https://app.terra.bio" if env == "prod"
-    else f"https://bvdp-saturn-{env}.appspot.com"
+    terra_url = (
+        "https://app.terra.bio"
+        if env == "prod"
+        else f"https://bvdp-saturn-{env}.appspot.com"
+    )
 
     w = workspace["workspace"]
 


### PR DESCRIPTION
Updated workspace generated catalog metadata to include `accessURL`, which contains the link to the corresponding terra workspace.

Also updated the HCA script generated accessURL, and other minor cleanups to the HCA code.