### PR TITLE
DC-422: Pin black version for build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.10'
       - name: Install black and link shellcheck into expected location
         run: |
-          pip install black
+          pip install black --force-reinstall black==22.3.0
           sudo ln -s $(which shellcheck) /usr/local/bin/shellcheck
       - name: Set up JDK
         uses: actions/setup-java@v2


### PR DESCRIPTION
Letting the black version float can cause a build failure when the default version installed by `pip install black` doesn't match the version specified by the spotless python plugin.