### PR TITLE
DC-427, DC-429, DC-360: nightly test fixes

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -143,7 +143,7 @@ jobs:
           status: ${{ env.STATUS }}
           fields: workflow,ref
           text: >
-            ${{ format('Catalog tests *{0}* in the {1} environment {2}',
+            ${{ format('Catalog test *{0}* in the {1} environment {2}',
             env.STATUS, needs.test-env.outputs.test-env,
             env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
           username: 'Data Explorer Tests'
@@ -169,7 +169,7 @@ jobs:
           status: ${{ env.STATUS }}
           fields: workflow,ref
           text: >
-            ${{ format('Catalog tests *{0}* in the {1} environment {2}',
+            ${{ format('Catalog test *{0}* in the {1} environment {2}',
             env.STATUS, needs.test-env.outputs.test-env,
             env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
           username: 'Data Explorer Tests'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -136,11 +136,11 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          author_name: ${{ github.event_name }}
+          author_name: ${{ github.actor }}
           channel: 'W016GLU78GM'
           status: 'failure'
-          fields: job,ref
-          text: ${{ format('{0} test run - status {1}', needs.test-env.outputs.test-env, 'failure') }}
+          fields: workflow,ref
+          text: ${{ format('{0} when running catalog tests in the {1} environment', env.STATUS, needs.test-env.outputs.test-env) }}
           username: 'Data Explorer Tests'
 
   notify-qa-slack:
@@ -149,28 +149,15 @@ jobs:
     if: always()
 
     steps:
-      - name: Dump GitHub context
-        id: github_context_step
-        run: echo '${{ toJSON(github) }}'
-      - name: Dump job context
-        run: echo '${{ toJSON(job) }}'
-      - name: Dump steps context
-        run: echo '${{ toJSON(steps) }}'
-      - name: Dump runner context
-        run: echo '${{ toJSON(runner) }}'
-      - name: Dump strategy context
-        run: echo '${{ toJSON(strategy) }}'
-      - name: Dump matrix context
-        run: echo '${{ toJSON(matrix) }}'
       - name: "Always notify #dsde-qa Slack"
         uses: broadinstitute/action-slack@v3.8.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           STATUS: ${{ needs.build.success && needs.jib.success && needs.test-env.success && needs.test-runner.success && 'success' || 'failure' }}
         with:
-          author_name: ${{ github.event_name }}
+          author_name: ${{ github.actor }}
           channel: 'W016GLU78GM'
           status: ${{ env.STATUS }}
-          fields: job,ref
-          text: ${{ format('{0} test run - status {1}', needs.test-env.outputs.test-env, env.STATUS) }}
+          fields: workflow,ref
+          text: ${{ format('{0} when running catalog tests in the {1} environment', env.STATUS, needs.test-env.outputs.test-env) }}
           username: 'Data Explorer Tests'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -142,7 +142,7 @@ jobs:
           status: ${{ env.STATUS }}
           fields: workflow,ref
           text: >
-            ${{ format('Catalog tests {0} in the {1} environment {2}',
+            ${{ format('Catalog tests *{0}* in the {1} environment {2}',
             env.STATUS, needs.test-env.outputs.test-env,
             env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
           username: 'Data Explorer Tests'
@@ -168,7 +168,7 @@ jobs:
           status: ${{ env.STATUS }}
           fields: workflow,ref
           text: >
-            ${{ format('Catalog tests {0} in the {1} environment {2}',
+            ${{ format('Catalog tests *{0}* in the {1} environment {2}',
             env.STATUS, needs.test-env.outputs.test-env,
             env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
           username: 'Data Explorer Tests'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -110,13 +110,12 @@ jobs:
 
       - name: Run perf test suite
         run: |
-          exit 1
-#          ./gradlew --build-cache runTest --args="suites/$TEST_ENV/FullIntegration.json build/reports"
+          ./gradlew --build-cache runTest --args="suites/$TEST_ENV/FullIntegration.json build/reports"
 
-#      - name: Upload Test Reports for QA
-#        if: always()
-#        run: |
-#          ./gradlew --build-cache uploadResults --args="CompressDirectoryToTerraKernelK8S.json build/reports"
+      - name: Upload Test Reports for QA
+        if: always()
+        run: |
+          ./gradlew --build-cache uploadResults --args="CompressDirectoryToTerraKernelK8S.json build/reports"
 
       - name: Upload Test Reports for GitHub
         if: always()
@@ -137,8 +136,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           STATUS: failure
         with:
+          channel: '#jade-data-explorer'
           author_name: ${{ github.actor }}
-          channel: 'W016GLU78GM'
           status: ${{ env.STATUS }}
           fields: workflow,ref
           text: >
@@ -163,8 +162,8 @@ jobs:
             && needs.test-runner.result == 'success'
             && 'success' || 'failure' }}
         with:
+          channel: '#dsde-qa'
           author_name: ${{ github.actor }}
-          channel: 'W016GLU78GM'
           status: ${{ env.STATUS }}
           fields: workflow,ref
           text: >

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -110,8 +110,7 @@ jobs:
 
       - name: Run perf test suite
         run: |
-          mkdir -p integration/build/reports
-          exit 0
+          exit 1
 #          ./gradlew --build-cache runTest --args="suites/$TEST_ENV/FullIntegration.json build/reports"
 
 #      - name: Upload Test Reports for QA

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -155,7 +155,7 @@ jobs:
         with:
           author_name: ${{ github.event_name }}
           channel: 'W016GLU78GM'
-          status: ${{ success() && 'success' || 'failure' }}
+          status: ${{ github.action_status }}
           fields: eventName,ref
           text: ${{ format('{0} test run, status {1}', needs.test-env.outputs.test-env, github.action_status) }}
           username: 'Data Explorer Tests'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Run perf test suite
         run: |
-           exit 1
+           exit 0
 #          ./gradlew --build-cache runTest --args="suites/$TEST_ENV/FullIntegration.json build/reports"
 
 #      - name: Upload Test Reports for QA
@@ -157,7 +157,7 @@ jobs:
         uses: broadinstitute/action-slack@v3.8.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          STATUS: >
+          STATUS: >-
             ${{ needs.build.result == 'success'
             && needs.jib.result == 'success'
             && needs.test-runner.result == 'success'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -67,16 +67,21 @@ jobs:
         with:
           image: ${{ steps.image-name.outputs.name }}
 
+  test-env:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set default test env
+        id: test-env
+        run: |
+          echo ::set-output name=test-env::${{ env.TEST_ENV || env.TEST_DEFAULT }}
+
   test-runner:
-    needs: [ build ]
+    needs: [ build, test-env ]
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Set default test env
-        run: |
-          echo "TEST_ENV=${{ env.TEST_ENV || env.TEST_DEFAULT }}" >> $GITHUB_ENV
 
       - name: Get the helm chart versions for the perf env
         run: |
@@ -86,8 +91,8 @@ jobs:
             --create-dirs -o "integration/src/main/resources/rendered/dev.yaml"
           curl -H 'Authorization: token ${{ secrets.BROADBOT_TOKEN }}' \
             -H 'Accept: application/vnd.github.v3.raw' \
-            -L https://api.github.com/repos/broadinstitute/terra-helmfile/contents/environments/live/$TEST_ENV.yaml \
-            --create-dirs -o "integration/src/main/resources/rendered/$TEST_ENV.yaml"
+            -L https://api.github.com/repos/broadinstitute/terra-helmfile/contents/environments/live/${{ test-env.outputs.test-env }}.yaml \
+            --create-dirs -o "integration/src/main/resources/rendered/${{ test-env.outputs.test-env }}.yaml"
 
       - name: Set up JDK
         uses: actions/setup-java@v2
@@ -104,9 +109,13 @@ jobs:
       - name: Run perf test suite
         run: |
           ./gradlew --build-cache runTest --args="suites/$TEST_ENV/FullIntegration.json build/reports"
+
+      - name: Upload Test Reports for QA
+        if: always()
+        run: |
           ./gradlew --build-cache uploadResults --args="CompressDirectoryToTerraKernelK8S.json build/reports"
 
-      - name: Upload Test Reports
+      - name: Upload Test Reports for GitHub
         if: always()
         uses: actions/upload-artifact@v1
         with:
@@ -114,7 +123,7 @@ jobs:
           path: integration/build/reports
 
   notify-de-slack:
-    needs: [ build, jib, test-runner ]
+    needs: [ build, jib, test-env, test-runner ]
     runs-on: ubuntu-latest
     if: failure()
 
@@ -124,15 +133,14 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          channel: '#jade-data-explorer'
-          status: ${{ needs.test-runner.result }}
-          author_name: Nightly test
-          fields: workflow,message
-          text: 'Nightly test failed :sadpanda:'
-          username: 'Data Explorer GitHub Action'
+          channel: 'W016GLU78GM'
+          status: 'failure'
+          fields: eventName,ref
+          text: ${{ format("{0} test run, status {1}", test-env.outputs.test-env, success() && 'success' || 'failure') }}
+          username: 'Data Explorer Tests'
 
   notify-qa-slack:
-    needs: [ build, jib, test-runner ]
+    needs: [ build, jib, test-env, test-runner ]
     runs-on: ubuntu-latest
     if: always()
 
@@ -142,9 +150,8 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          channel: '#dsde-qa'
-          status: ${{ needs.test-runner.result }}
-          author_name: Nightly test
-          fields: workflow,message
-          text: 'Nightly performance test results'
-          username: 'Data Explorer GitHub Action'
+          channel: 'W016GLU78GM'
+          status: ${{ success() && 'success' || 'failure' }}
+          fields: eventName,ref
+          text: ${{ format("{0} test run, status {1}", test-env.outputs.test-env, success() && 'success' || 'failure') }}
+          username: 'Data Explorer Tests'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Run perf test suite
         run: |
-          mkdir -p build/reports
+          mkdir -p integration/build/reports
           exit 0
 #          ./gradlew --build-cache runTest --args="suites/$TEST_ENV/FullIntegration.json build/reports"
 

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -139,7 +139,7 @@ jobs:
           channel: 'W016GLU78GM'
           status: 'failure'
           fields: eventName,ref
-          text: ${{ format('{0} test run, status {1}', needs.test-env.outputs.test-env, 'failure') }}
+          text: ${{ format('{0} test run - status {1}', needs.test-env.outputs.test-env, 'failure') }}
           username: 'Data Explorer Tests'
 
   notify-qa-slack:
@@ -152,10 +152,11 @@ jobs:
         uses: broadinstitute/action-slack@v3.8.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          STATUS: ${{ needs.build.success && needs.jib.success && needs.test-env.success && needs.test-runner.success && 'success' || 'failure' }}
         with:
           author_name: ${{ github.event_name }}
           channel: 'W016GLU78GM'
-          status: ${{ github.action_status }}
+          status: ${{ env.STATUS }}
           fields: eventName,ref
-          text: ${{ format('{0} test run, status {1}', needs.test-env.outputs.test-env, github.action_status) }}
+          text: ${{ format('{0} test run - status {1}', needs.test-env.outputs.test-env, env.STATUS) }}
           username: 'Data Explorer Tests'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -69,6 +69,8 @@ jobs:
 
   test-env:
     runs-on: ubuntu-latest
+    outputs:
+      test-env: ${{ steps.test-env.outputs.test-env }}
 
     steps:
       - name: Set default test env
@@ -91,8 +93,8 @@ jobs:
             --create-dirs -o "integration/src/main/resources/rendered/dev.yaml"
           curl -H 'Authorization: token ${{ secrets.BROADBOT_TOKEN }}' \
             -H 'Accept: application/vnd.github.v3.raw' \
-            -L https://api.github.com/repos/broadinstitute/terra-helmfile/contents/environments/live/${{ test-env.outputs.test-env }}.yaml \
-            --create-dirs -o "integration/src/main/resources/rendered/${{ test-env.outputs.test-env }}.yaml"
+            -L https://api.github.com/repos/broadinstitute/terra-helmfile/contents/environments/live/${{ needs.test-env.outputs.test-env }}.yaml \
+            --create-dirs -o "integration/src/main/resources/rendered/${{ needs.test-env.outputs.test-env }}.yaml"
 
       - name: Set up JDK
         uses: actions/setup-java@v2
@@ -136,7 +138,7 @@ jobs:
           channel: 'W016GLU78GM'
           status: 'failure'
           fields: eventName,ref
-          text: ${{ format("{0} test run, status {1}", test-env.outputs.test-env, success() && 'success' || 'failure') }}
+          text: ${{ format('{0} test run, status {1}', needs.test-env.outputs.test-env, success() && 'success' || 'failure') }}
           username: 'Data Explorer Tests'
 
   notify-qa-slack:
@@ -153,5 +155,5 @@ jobs:
           channel: 'W016GLU78GM'
           status: ${{ success() && 'success' || 'failure' }}
           fields: eventName,ref
-          text: ${{ format("{0} test run, status {1}", test-env.outputs.test-env, success() && 'success' || 'failure') }}
+          text: ${{ format('{0} test run, status {1}', needs.test-env.outputs.test-env, success() && 'success' || 'failure') }}
           username: 'Data Explorer Tests'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -135,7 +135,7 @@ jobs:
         uses: broadinstitute/action-slack@v3.8.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          STATUS: failed
+          STATUS: failure
         with:
           author_name: ${{ github.actor }}
           channel: 'W016GLU78GM'
@@ -143,8 +143,8 @@ jobs:
           fields: workflow,ref
           text: >
             ${{ format('Catalog tests {0} in the {1} environment {2}',
-                env.STATUS, needs.test-env.outputs.test-env,
-                env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
+            env.STATUS, needs.test-env.outputs.test-env,
+            env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
           username: 'Data Explorer Tests'
 
   notify-qa-slack:
@@ -158,10 +158,10 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           STATUS: >
-            ${{ needs.build.result == 'success' &&
-                needs.jib.result == 'success' &&
-                needs.test-runner.result == 'success' &&
-                'success' || 'failure' }}
+            ${{ needs.build.result == 'success'
+            && needs.jib.result == 'success'
+            && needs.test-runner.result == 'success'
+            && 'success' || 'failure' }}
         with:
           author_name: ${{ github.actor }}
           channel: 'W016GLU78GM'
@@ -169,6 +169,6 @@ jobs:
           fields: workflow,ref
           text: >
             ${{ format('Catalog tests {0} in the {1} environment {2}',
-                env.STATUS, needs.test-env.outputs.test-env,
-                env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
+            env.STATUS, needs.test-env.outputs.test-env,
+            env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
           username: 'Data Explorer Tests'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -110,7 +110,8 @@ jobs:
 
       - name: Run perf test suite
         run: |
-           exit 0
+          mkdir -p build/reports
+          exit 0
 #          ./gradlew --build-cache runTest --args="suites/$TEST_ENV/FullIntegration.json build/reports"
 
 #      - name: Upload Test Reports for QA

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -135,12 +135,16 @@ jobs:
         uses: broadinstitute/action-slack@v3.8.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          STATUS: failed
         with:
           author_name: ${{ github.actor }}
           channel: 'W016GLU78GM'
-          status: 'failure'
+          status: ${{ env.STATUS }}
           fields: workflow,ref
-          text: ${{ format('{0} when running catalog tests in the {1} environment', env.STATUS, needs.test-env.outputs.test-env) }}
+          text: >
+            ${{ format('Catalog tests {0} in the {1} environment {2}',
+                env.STATUS, needs.test-env.outputs.test-env,
+                env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
           username: 'Data Explorer Tests'
 
   notify-qa-slack:
@@ -153,11 +157,18 @@ jobs:
         uses: broadinstitute/action-slack@v3.8.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          STATUS: ${{ needs.build.success && needs.jib.success && needs.test-env.success && needs.test-runner.success && 'success' || 'failure' }}
+          STATUS: >
+            ${{ needs.build.result == 'success' &&
+                needs.jib.result == 'success' &&
+                needs.test-runner.result == 'success' &&
+                'success' || 'failure' }}
         with:
           author_name: ${{ github.actor }}
           channel: 'W016GLU78GM'
           status: ${{ env.STATUS }}
           fields: workflow,ref
-          text: ${{ format('{0} when running catalog tests in the {1} environment', env.STATUS, needs.test-env.outputs.test-env) }}
+          text: >
+            ${{ format('Catalog tests {0} in the {1} environment {2}',
+                env.STATUS, needs.test-env.outputs.test-env,
+                env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
           username: 'Data Explorer Tests'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -143,7 +143,7 @@ jobs:
           status: ${{ env.STATUS }}
           fields: workflow,ref
           text: >
-            ${{ format('Catalog test *{0}* in the {1} environment {2}',
+            ${{ format('Catalog test *{0}* in *{1}* {2}',
             env.STATUS, needs.test-env.outputs.test-env,
             env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
           username: 'Data Explorer Tests'
@@ -169,7 +169,7 @@ jobs:
           status: ${{ env.STATUS }}
           fields: workflow,ref
           text: >
-            ${{ format('Catalog test *{0}* in the {1} environment {2}',
+            ${{ format('Catalog test *{0}* in *{1}* {2}',
             env.STATUS, needs.test-env.outputs.test-env,
             env.STATUS == 'success' && ':check_green:' || ':sadpanda:') }}
           username: 'Data Explorer Tests'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -110,12 +110,13 @@ jobs:
 
       - name: Run perf test suite
         run: |
-          ./gradlew --build-cache runTest --args="suites/$TEST_ENV/FullIntegration.json build/reports"
+           exit 1
+#          ./gradlew --build-cache runTest --args="suites/$TEST_ENV/FullIntegration.json build/reports"
 
-      - name: Upload Test Reports for QA
-        if: always()
-        run: |
-          ./gradlew --build-cache uploadResults --args="CompressDirectoryToTerraKernelK8S.json build/reports"
+#      - name: Upload Test Reports for QA
+#        if: always()
+#        run: |
+#          ./gradlew --build-cache uploadResults --args="CompressDirectoryToTerraKernelK8S.json build/reports"
 
       - name: Upload Test Reports for GitHub
         if: always()
@@ -138,7 +139,7 @@ jobs:
           author_name: ${{ github.event_name }}
           channel: 'W016GLU78GM'
           status: 'failure'
-          fields: eventName,ref
+          fields: job,ref
           text: ${{ format('{0} test run - status {1}', needs.test-env.outputs.test-env, 'failure') }}
           username: 'Data Explorer Tests'
 
@@ -148,6 +149,19 @@ jobs:
     if: always()
 
     steps:
+      - name: Dump GitHub context
+        id: github_context_step
+        run: echo '${{ toJSON(github) }}'
+      - name: Dump job context
+        run: echo '${{ toJSON(job) }}'
+      - name: Dump steps context
+        run: echo '${{ toJSON(steps) }}'
+      - name: Dump runner context
+        run: echo '${{ toJSON(runner) }}'
+      - name: Dump strategy context
+        run: echo '${{ toJSON(strategy) }}'
+      - name: Dump matrix context
+        run: echo '${{ toJSON(matrix) }}'
       - name: "Always notify #dsde-qa Slack"
         uses: broadinstitute/action-slack@v3.8.0
         env:
@@ -157,6 +171,6 @@ jobs:
           author_name: ${{ github.event_name }}
           channel: 'W016GLU78GM'
           status: ${{ env.STATUS }}
-          fields: eventName,ref
+          fields: job,ref
           text: ${{ format('{0} test run - status {1}', needs.test-env.outputs.test-env, env.STATUS) }}
           username: 'Data Explorer Tests'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -135,10 +135,11 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
+          author_name: ${{ github.event_name }}
           channel: 'W016GLU78GM'
           status: 'failure'
           fields: eventName,ref
-          text: ${{ format('{0} test run, status {1}', needs.test-env.outputs.test-env, success() && 'success' || 'failure') }}
+          text: ${{ format('{0} test run, status {1}', needs.test-env.outputs.test-env, 'failure') }}
           username: 'Data Explorer Tests'
 
   notify-qa-slack:
@@ -152,8 +153,9 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
+          author_name: ${{ github.event_name }}
           channel: 'W016GLU78GM'
           status: ${{ success() && 'success' || 'failure' }}
           fields: eventName,ref
-          text: ${{ format('{0} test run, status {1}', needs.test-env.outputs.test-env, success() && 'success' || 'failure') }}
+          text: ${{ format('{0} test run, status {1}', needs.test-env.outputs.test-env, github.action_status) }}
           username: 'Data Explorer Tests'

--- a/integration/src/main/resources/servers/catalog-alpha.json
+++ b/integration/src/main/resources/servers/catalog-alpha.json
@@ -6,16 +6,6 @@
   "datarepoUri": "https://data.alpha.envs-terra.bio/",
   "rawlsUri": "https://rawls.dsde-alpha.broadinstitute.org/",
 
-  "cluster": {
-    "clusterName": "terra-alpha",
-    "clusterShortName": "terra-alpha",
-    "region": "us-central1",
-    "zone": "us-central1-a",
-    "project": "broad-dsde-alpha",
-    "namespace": "terra-alpha",
-    "containerName": "catalog",
-    "apiComponentLabel":  "catalog"
-  },
   "deploymentScript": {},
   "testRunnerServiceAccountFile": "testrunner-perf.json",
 

--- a/integration/src/main/resources/servers/catalog-perf.json
+++ b/integration/src/main/resources/servers/catalog-perf.json
@@ -6,16 +6,6 @@
   "datarepoUri": "https://jade.datarepo-dev.broadinstitute.org/",
   "rawlsUri": "https://rawls.dsde-perf.broadinstitute.org/",
 
-  "cluster": {
-    "clusterName": "terra-perf",
-    "clusterShortName": "terra-perf",
-    "region": "us-central1",
-    "zone": "us-central1-a",
-    "project": "broad-dsde-perf",
-    "namespace": "terra-perf",
-    "containerName": "catalog",
-    "apiComponentLabel":  "catalog"
-  },
   "deploymentScript": {},
   "testRunnerServiceAccountFile": "testrunner-perf.json",
 

--- a/integration/src/main/resources/servers/catalog-staging.json
+++ b/integration/src/main/resources/servers/catalog-staging.json
@@ -6,16 +6,6 @@
   "datarepoUri": "https://data.staging.envs-terra.bio/",
   "rawlsUri": "https://rawls.dsde-staging.broadinstitute.org/",
 
-  "cluster": {
-    "clusterName": "terra-staging",
-    "clusterShortName": "terra-staging",
-    "region": "us-central1",
-    "zone": "us-central1-a",
-    "project": "broad-dsde-staging",
-    "namespace": "terra-staging",
-    "containerName": "catalog",
-    "apiComponentLabel":  "catalog"
-  },
   "deploymentScript": {},
   "testRunnerServiceAccountFile": "testrunner-perf.json",
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name = 'terra-data-catalog'
 include('service', 'client', 'rawls-client', 'integration', 'scripts')
 
-gradle.ext.releaseVersion = '0.78.0'
+gradle.ext.releaseVersion = '0.79.0'


### PR DESCRIPTION
This fixes a few issues with the catalog nightly test:

- add status and env to slack message [DC-427](https://broadworkbench.atlassian.net/browse/DC-427)
- always upload integration test data to QA bucket [DC-429](https://broadworkbench.atlassian.net/browse/DC-429)
- remove unused cluster specifications from integration test configs
- fix issue where failed build could show as green in Slack [DC-360](https://broadworkbench.atlassian.net/browse/DC-360)

message on success:
<img width="551" alt="image" src="https://user-images.githubusercontent.com/1799360/177845714-d6c559fe-bb54-4870-a9be-bc53697074fc.png">

message on failure:
<img width="551" alt="image" src="https://user-images.githubusercontent.com/1799360/177846967-af724998-1b5a-4f17-aa0e-9ad7d3e316da.png">

