### PR TITLE
[DC-419] Admins can list all datasets, even if they don't have permissions on originating resource

### DIFF
--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -75,15 +75,15 @@ public class DatasetService {
       node.set("id", TextNode.valueOf(dataset.id().toValue()));
       return node;
     }
-  }
 
-  private ObjectNode toJsonNode(String json) {
-    try {
-      return objectMapper.readValue(json, ObjectNode.class);
-    } catch (JsonProcessingException e) {
-      // This shouldn't occur, as the data stored in postgres must be valid JSON, because it's
-      // stored as JSONB.
-      throw new IllegalMetadataException(e);
+    private ObjectNode toJsonNode(String json) {
+      try {
+        return objectMapper.readValue(json, ObjectNode.class);
+      } catch (JsonProcessingException e) {
+        // This shouldn't occur, as the data stored in postgres must be valid JSON, because it's
+        // stored as JSONB.
+        throw new IllegalMetadataException(e);
+      }
     }
   }
 

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -22,9 +22,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -56,6 +56,27 @@ public class DatasetService {
     }
   }
 
+  private class DatasetWithAccessLevel {
+    private final Dataset dataset;
+    private final DatasetAccessLevel accessLevel;
+
+    public DatasetWithAccessLevel(Dataset dataset, DatasetAccessLevel accessLevel) {
+      this.dataset = dataset;
+      this.accessLevel = accessLevel;
+    }
+
+    public Dataset getDataset() {
+      return dataset;
+    }
+
+    public Object convertToObject() {
+      ObjectNode node = toJsonNode(dataset.metadata());
+      node.set("accessLevel", TextNode.valueOf(String.valueOf(accessLevel)));
+      node.set("id", TextNode.valueOf(dataset.id().toValue()));
+      return node;
+    }
+  }
+
   private ObjectNode toJsonNode(String json) {
     try {
       return objectMapper.readValue(json, ObjectNode.class);
@@ -66,48 +87,45 @@ public class DatasetService {
     }
   }
 
-  private List<ObjectNode> convertSourceObjectsToDatasetResponses(
+  private List<DatasetWithAccessLevel> convertSourceObjectsToDatasetsWithAccessLevel(
       Map<String, DatasetAccessLevel> roleMap, StorageSystem storageSystem) {
     List<Dataset> datasets = datasetDao.find(storageSystem, roleMap.keySet());
     return datasets.stream()
-        .map(dataset -> sourceAndDatasetToObjectNode(roleMap, dataset))
+        .map(dataset -> new DatasetWithAccessLevel(dataset, roleMap.get(dataset.storageSourceId())))
         .toList();
   }
 
-  private ObjectNode sourceAndDatasetToObjectNode(
-      Map<String, DatasetAccessLevel> roleMap, Dataset dataset) {
-    ObjectNode node = toJsonNode(dataset.metadata());
-    node.set(
-        "accessLevel", TextNode.valueOf(String.valueOf(roleMap.get(dataset.storageSourceId()))));
-    node.set("id", TextNode.valueOf(dataset.id().toValue()));
-    return node;
-  }
-
-  private List<ObjectNode> collectDatarepoDatasets(AuthenticatedUserRequest user) {
+  private List<DatasetWithAccessLevel> collectDatarepoDatasets(AuthenticatedUserRequest user) {
     // For this storage system, get the collection of visible datasets and the user's roles for
     // each dataset.
     var roleMap = datarepoService.getSnapshotIdsAndRoles(user);
-    return convertSourceObjectsToDatasetResponses(roleMap, StorageSystem.TERRA_DATA_REPO);
+    return convertSourceObjectsToDatasetsWithAccessLevel(roleMap, StorageSystem.TERRA_DATA_REPO);
   }
 
-  private List<ObjectNode> collectWorkspaceDatasets(AuthenticatedUserRequest user) {
+  private List<DatasetWithAccessLevel> collectWorkspaceDatasets(AuthenticatedUserRequest user) {
     var roleMap = rawlsService.getWorkspaceIdsAndRoles(user);
-    return convertSourceObjectsToDatasetResponses(roleMap, StorageSystem.TERRA_WORKSPACE);
+    return convertSourceObjectsToDatasetsWithAccessLevel(roleMap, StorageSystem.TERRA_WORKSPACE);
   }
 
   public DatasetsListResponse listDatasets(AuthenticatedUserRequest user) {
+    List<DatasetWithAccessLevel> datasets = new ArrayList<>();
+    datasets.addAll(collectWorkspaceDatasets(user));
+    datasets.addAll(collectDatarepoDatasets(user));
+    if (samService.hasGlobalAction(user, SamAction.READ_ANY_METADATA)) {
+      datasets.addAll(
+          datasetDao.listAllDatasets().stream()
+              .map(dataset -> new DatasetWithAccessLevel(dataset, DatasetAccessLevel.READER))
+              .filter(
+                  datasetWithAccessLevel ->
+                      !datasets.stream()
+                          .map(datasetInList -> datasetInList.getDataset().id())
+                          .toList()
+                          .contains(datasetWithAccessLevel.getDataset().id()))
+              .toList());
+    }
     var response = new DatasetsListResponse();
 
-    response.getResult().addAll(collectWorkspaceDatasets(user));
-    response.getResult().addAll(collectDatarepoDatasets(user));
-    if (samService.hasGlobalAction(user, SamAction.READ_ANY_METADATA)) {
-      List<Dataset> datasetsList = datasetDao.listAllDatasets();
-      Map<String, DatasetAccessLevel> roleMap = datasetsList.stream().collect(Collectors.toMap(Dataset::storageSourceId, dataset2 -> DatasetAccessLevel.READER));
-      response.getResult().addAll(datasetsList.stream()
-          .map(dataset -> sourceAndDatasetToObjectNode(roleMap, dataset))
-          .toList());
-      return response;
-    }
+    response.setResult(datasets.stream().map(DatasetWithAccessLevel::convertToObject).toList());
     return response;
   }
 

--- a/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
+++ b/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
@@ -127,6 +127,7 @@ public class DatasetDao {
 
   @ReadTransaction
   public List<Dataset> listAllDatasets() {
-    return jdbcTemplate.query("SELECT * FROM dataset", new DatasetMapper());
+    String sql = "SELECT * FROM dataset";
+    return jdbcTemplate.query(sql, new DatasetMapper());
   }
 }

--- a/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
+++ b/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
@@ -37,14 +37,6 @@ public class DatasetDao {
   }
 
   @ReadTransaction
-  public List<Dataset> enumerate() {
-    String sql =
-        "SELECT id, storage_source_id, storage_system, metadata, created_date FROM dataset";
-    MapSqlParameterSource params = new MapSqlParameterSource();
-    return jdbcTemplate.query(sql, params, new DatasetMapper());
-  }
-
-  @ReadTransaction
   public Dataset retrieve(DatasetId id) {
     String sql =
         "SELECT id, storage_source_id, storage_system, metadata, created_date FROM dataset WHERE id = :id";

--- a/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
+++ b/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
@@ -132,4 +132,9 @@ public class DatasetDao {
     var params = Map.of("storageSystem", String.valueOf(storageSystem), "ids", ids);
     return jdbcTemplate.query(sql, params, new DatasetMapper());
   }
+
+  @ReadTransaction
+  public List<Dataset> listAllDatasets() {
+    return jdbcTemplate.query("SELECT * FROM dataset", new DatasetMapper());
+  }
 }

--- a/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
@@ -2,7 +2,6 @@ package bio.terra.catalog.service.dataset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
@@ -2,6 +2,7 @@ package bio.terra.catalog.service.dataset;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -64,7 +65,7 @@ class DatasetDaoTest {
     createDataset(storageSourceId, StorageSystem.TERRA_DATA_REPO);
     createDataset(storageSourceId, StorageSystem.TERRA_WORKSPACE);
     long datasetCount =
-        datasetDao.enumerate().stream()
+        datasetDao.listAllDatasets().stream()
             .filter(dataset -> dataset.storageSourceId().equals(storageSourceId))
             .count();
     assertEquals(2L, datasetCount);


### PR DESCRIPTION
Tested to make sure things weren't double listed.