### PR TITLE
DC-450: Remove jstl library

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     implementation 'org.postgresql:postgresql:42.3.3'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-    implementation 'javax.servlet:jstl:1.2'
     implementation project(':rawls-client')
 
     liquibaseRuntime 'org.liquibase:liquibase-core:3.10.0'


### PR DESCRIPTION
This library doesn't seem to be necessary to build or run the project and has a vulnerability.