### PR TITLE
DC-542: fix regression where container main class was moved but config wasn't updated

### DIFF
--- a/service/publishing.gradle
+++ b/service/publishing.gradle
@@ -28,7 +28,7 @@ jib {
     }
     container {
         filesModificationTime = ZonedDateTime.now().toString() // to prevent ui caching
-        mainClass = 'bio.terra.catalog.app.App'
+        mainClass = 'bio.terra.catalog.App'
         jvmFlags = [
             "-agentpath:" + cloudProfilerLocation + "/profiler_java_agent.so=" +
                 "-cprof_service=bio.terra.catalog" +


### PR DESCRIPTION
Since our PR tests don't run the container, no error was generated before the merge.