### PR TITLE
DC-592: GitHub action fixes: remove use of `set-output`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
       - name: Install black and link shellcheck into expected location
@@ -22,7 +22,7 @@ jobs:
           pip install black --force-reinstall black==22.3.0
           sudo ln -s $(which shellcheck) /usr/local/bin/shellcheck
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -54,7 +54,7 @@ jobs:
         run: |
           GITHUB_REPO=$(basename ${{ github.repository }})
           GIT_SHORT_HASH=$(git rev-parse --short HEAD)
-          echo ::set-output name=name::${GITHUB_REPO}:${GIT_SHORT_HASH}
+          echo "name=${GITHUB_REPO}:${GIT_SHORT_HASH}" >> $GITHUB_OUTPUT
 
       - name: Build image locally with jib
         run: |
@@ -81,9 +81,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -106,12 +106,12 @@ jobs:
         ports: [ "5432:5432" ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         # Needed by sonar to get the git history for the branch the PR will be merged into.
         with:
           fetch-depth: 0
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -146,9 +146,9 @@ jobs:
         ports: [ "5432:5432" ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -172,9 +172,8 @@ jobs:
       - name: Wait for boot run to be ready
         run: |
           set +e
-          timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
+          resultStatus=$(timeout --preserve-status 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done')
           set -e
-          resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
           if [[ $resultStatus == 0 ]]; then
             echo "Server started successfully"
           else

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -171,7 +171,9 @@ jobs:
 
       - name: Wait for boot run to be ready
         run: |
-          timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
+          set +e
+          timeout 1 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
+          set -e
           resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
           if [[ $resultStatus == 0 ]]; then
             echo "Server started successfully"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Wait for boot run to be ready
         run: |
           set +e
-          timeout 1 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
+          timeout 4 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
           set -e
           resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
           if [[ $resultStatus == 0 ]]; then

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Wait for boot run to be ready
         run: |
           set +e
-          timeout 4 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
+          timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
           set -e
           resultStatus=$(echo > /dev/tcp/localhost/8080; echo $?)
           if [[ $resultStatus == 0 ]]; then

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -172,7 +172,8 @@ jobs:
       - name: Wait for boot run to be ready
         run: |
           set +e
-          resultStatus=$(timeout --preserve-status 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done')
+          timeout 60 bash -c 'until echo > /dev/tcp/localhost/8080; do sleep 1; done'
+          resultStatus=$?
           set -e
           if [[ $resultStatus == 0 ]]; then
             echo "Server started successfully"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -38,9 +38,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -51,7 +51,7 @@ jobs:
         run: |
           GITHUB_REPO=$(basename ${{ github.repository }})
           GIT_SHORT_HASH=$(git rev-parse --short HEAD)
-          echo ::set-output name=name::${GITHUB_REPO}:${GIT_SHORT_HASH}
+          echo "name=${GITHUB_REPO}:${GIT_SHORT_HASH}" >> $GITHUB_OUTPUT
 
       - name: Build image locally with jib
         run: |
@@ -79,14 +79,14 @@ jobs:
       - name: Set default test env
         id: test-env
         run: |
-          echo ::set-output name=test-env::${{ env.TEST_ENV || env.TEST_DEFAULT }}
+          echo "test-env=${{ env.TEST_ENV || env.TEST_DEFAULT }}" >> $GITHUB_OUTPUT
 
   test-runner:
     needs: [ build, test-env ]
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get the helm chart versions for the test env
         run: |
@@ -100,7 +100,7 @@ jobs:
             --create-dirs -o "integration/src/main/resources/rendered/${{ needs.test-env.outputs.test-env }}.yaml"
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -20,7 +20,7 @@ jobs:
 
       - name: Parse tag
         id: tag
-        run: echo ::set-output name=tag::$(git describe --tags)
+        run: echo "tag=$(git describe --tags)" >> $GITHUB_OUTPUT
 
       - name: Publish to Artifactory
         run: ./gradlew --build-cache :client:artifactoryPublish
@@ -39,7 +39,7 @@ jobs:
 
       - name: Construct docker image name and tag
         id: image-name
-        run: echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}
+        run: echo "name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}" >> $GITHUB_OUTPUT
 
       - name: Build image locally with jib
         run: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -5,10 +5,10 @@ jobs:
   trivy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -20,7 +20,7 @@ jobs:
       - name: Construct docker image name and tag
         id: image-name
         run: |
-          echo ::set-output name=name::trivy-local-testing-image
+          echo "name=trivy-local-testing-image" >> $GITHUB_OUTPUT
 
       - name: Build image locally with jib
         run: |

--- a/integration/src/main/resources/configs/integration/DatasetOperations.json
+++ b/integration/src/main/resources/configs/integration/DatasetOperations.json
@@ -9,7 +9,7 @@
       "name": "DatasetOperations",
       "numberOfUserJourneyThreadsToRun": 1,
       "userJourneyThreadPoolSize": 2,
-      "expectedTimeForEach": 5,
+      "expectedTimeForEach": 10,
       "expectedTimeForEachUnit": "SECONDS"
     }
   ],


### PR DESCRIPTION
Also 
- update actions to newer versions to fix node version warning
- fix issue where failure to start server didn't result in boot logs being printed out
- increase test timeout