### PR TITLE
DC-561: fix case where an unknown role from TDR would cause an NPE

### DIFF
--- a/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
+++ b/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
@@ -56,6 +56,7 @@ public class DatarepoService implements StorageSystemService {
     for (DatasetAccessLevel datasetAccessLevel : DatasetAccessLevel.values()) {
       if (roles.stream()
           .map(ROLE_TO_DATASET_ACCESS::get)
+          // Ignore roles we don't recognize.
           .filter(Objects::nonNull)
           .anyMatch(
               roleAsDatasetAccessLevel -> roleAsDatasetAccessLevel.equals(datasetAccessLevel))) {

--- a/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
+++ b/service/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
@@ -18,6 +18,7 @@ import bio.terra.datarepo.model.SnapshotPreviewModel;
 import bio.terra.datarepo.model.SnapshotRetrieveIncludeModel;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -55,6 +56,7 @@ public class DatarepoService implements StorageSystemService {
     for (DatasetAccessLevel datasetAccessLevel : DatasetAccessLevel.values()) {
       if (roles.stream()
           .map(ROLE_TO_DATASET_ACCESS::get)
+          .filter(Objects::nonNull)
           .anyMatch(
               roleAsDatasetAccessLevel -> roleAsDatasetAccessLevel.equals(datasetAccessLevel))) {
         return datasetAccessLevel;

--- a/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
@@ -91,19 +91,18 @@ class DatarepoServiceTest {
 
   static Object[][] getRole() {
     return new Object[][] {
-      {List.of(DatarepoService.READER_ROLE_NAME), DatasetAccessLevel.READER},
-      {List.of(DatarepoService.STEWARD_ROLE_NAME), DatasetAccessLevel.OWNER},
-      {List.of(), DatasetAccessLevel.NO_ACCESS},
-      {List.of("unknown role"), DatasetAccessLevel.NO_ACCESS}
+      {DatarepoService.READER_ROLE_NAME, DatasetAccessLevel.READER},
+      {DatarepoService.STEWARD_ROLE_NAME, DatasetAccessLevel.OWNER},
+      {"unknown role", DatasetAccessLevel.NO_ACCESS}
     };
   }
 
   @ParameterizedTest
   @MethodSource
-  void getRole(List<String> datarepoRoles, DatasetAccessLevel catalogRole) throws Exception {
+  void getRole(String datarepoRole, DatasetAccessLevel catalogRole) throws Exception {
     mockSnapshots();
     var id = UUID.randomUUID();
-    when(snapshotsApi.retrieveUserSnapshotRoles(id)).thenReturn(datarepoRoles);
+    when(snapshotsApi.retrieveUserSnapshotRoles(id)).thenReturn(List.of(datarepoRole));
     assertThat(datarepoService.getRole(user, id.toString()), is(catalogRole));
   }
 

--- a/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
@@ -99,11 +99,11 @@ class DatarepoServiceTest {
 
   @ParameterizedTest
   @MethodSource
-  void getRole(String datarepoRole, DatasetAccessLevel catalogRole) throws Exception {
+  void getRole(String datarepoRole, DatasetAccessLevel expectedCatalogRole) throws Exception {
     mockSnapshots();
     var id = UUID.randomUUID();
     when(snapshotsApi.retrieveUserSnapshotRoles(id)).thenReturn(List.of(datarepoRole));
-    assertThat(datarepoService.getRole(user, id.toString()), is(catalogRole));
+    assertThat(datarepoService.getRole(user, id.toString()), is(expectedCatalogRole));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
@@ -32,6 +32,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -87,30 +89,22 @@ class DatarepoServiceTest {
     assertThrows(DatarepoException.class, () -> datarepoService.getDatasets(user));
   }
 
-  @Test
-  void getRoleReader() throws Exception {
-    mockSnapshots();
-    var id = UUID.randomUUID();
-    when(snapshotsApi.retrieveUserSnapshotRoles(id))
-        .thenReturn(List.of(DatarepoService.READER_ROLE_NAME));
-    assertThat(datarepoService.getRole(user, id.toString()), is(DatasetAccessLevel.READER));
+  static Object[][] getRole() {
+    return new Object[][] {
+      {List.of(DatarepoService.READER_ROLE_NAME), DatasetAccessLevel.READER},
+      {List.of(DatarepoService.STEWARD_ROLE_NAME), DatasetAccessLevel.OWNER},
+      {List.of(), DatasetAccessLevel.NO_ACCESS},
+      {List.of("unknown role"), DatasetAccessLevel.NO_ACCESS}
+    };
   }
 
-  @Test
-  void getRoleSteward() throws Exception {
+  @ParameterizedTest
+  @MethodSource
+  void getRole(List<String> datarepoRoles, DatasetAccessLevel catalogRole) throws Exception {
     mockSnapshots();
     var id = UUID.randomUUID();
-    when(snapshotsApi.retrieveUserSnapshotRoles(id))
-        .thenReturn(List.of(DatarepoService.STEWARD_ROLE_NAME));
-    assertThat(datarepoService.getRole(user, id.toString()), is(DatasetAccessLevel.OWNER));
-  }
-
-  @Test
-  void getRoleNoAccess() throws Exception {
-    mockSnapshots();
-    var id = UUID.randomUUID();
-    when(snapshotsApi.retrieveUserSnapshotRoles(id)).thenReturn(List.of());
-    assertThat(datarepoService.getRole(user, id.toString()), is(DatasetAccessLevel.NO_ACCESS));
+    when(snapshotsApi.retrieveUserSnapshotRoles(id)).thenReturn(datarepoRoles);
+    assertThat(datarepoService.getRole(user, id.toString()), is(catalogRole));
   }
 
   @Test


### PR DESCRIPTION
The code that converts the TDR role to a catalog role doesn't have all possible roles, and roles aren't part of the generated client API as an enum. To avoid an NPE in the future, and to avoid the need to list all possible roles, filter out TDR roles that the catalog doesn't recognize.