### PR TITLE
DC-464: Fix issue where path to resource didn't use a resource path lookup

### DIFF
--- a/integration/src/main/java/scripts/testscripts/DatasetOperations.java
+++ b/integration/src/main/java/scripts/testscripts/DatasetOperations.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.api.client.http.HttpStatusCodes;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -83,14 +84,14 @@ public class DatasetOperations extends TestScript {
     snapshotId = snapshotsApi.createTestSnapshot(tdrDataset);
   }
 
-  private ObjectNode createMetadata(String title) {
+  public static ObjectNode createMetadata(String title) {
     var obj =
         objectMapper
             .createObjectNode()
             .put("dct:title", title)
             .put("dct:description", "description")
             .put("dct:creator", "creator")
-            .put("dct:issued", "2008-11-01T19:35:00.0000000Z")
+            .put("dct:issued", Instant.now().toString())
             .put("dcat:accessURL", "url");
     obj.putArray("TerraDCAT_ap:hasDataCollection").addAll(List.of());
     obj.putArray("prov:wasGeneratedBy").addAll(List.of());

--- a/integration/src/main/java/scripts/testscripts/DatasetPermissionOperations.java
+++ b/integration/src/main/java/scripts/testscripts/DatasetPermissionOperations.java
@@ -15,7 +15,6 @@ import bio.terra.rawls.model.WorkspaceAccessLevel;
 import bio.terra.rawls.model.WorkspaceDetails;
 import bio.terra.testrunner.runner.TestScript;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.HttpStatusCodes;
 import java.util.ArrayList;
 import java.util.List;

--- a/integration/src/main/java/scripts/testscripts/DatasetPermissionOperations.java
+++ b/integration/src/main/java/scripts/testscripts/DatasetPermissionOperations.java
@@ -16,7 +16,6 @@ import bio.terra.rawls.model.WorkspaceDetails;
 import bio.terra.testrunner.runner.TestScript;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.api.client.http.HttpStatusCodes;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,8 +32,6 @@ import scripts.client.RawlsClient;
 public class DatasetPermissionOperations extends TestScript {
 
   private static final Logger log = LoggerFactory.getLogger(DatasetPermissionOperations.class);
-
-  private static final ObjectMapper objectMapper = new ObjectMapper();
   private static final String ADMIN_EMAIL = "datacatalogadmin@test.firecloud.org";
   private static final String USER_EMAIL = "datacataloguser@test.firecloud.org";
 
@@ -209,29 +206,11 @@ public class DatasetPermissionOperations extends TestScript {
   }
 
   private CreateDatasetRequest datasetRequest(String sourceId, StorageSystem storageSystem) {
-    final String metadata = createMetadata("test").toString();
+    final String metadata = DatasetOperations.createMetadata("test").toString();
     return new CreateDatasetRequest()
         .catalogEntry(metadata)
         .storageSourceId(sourceId)
         .storageSystem(storageSystem);
-  }
-
-  private ObjectNode createMetadata(String title) {
-    var obj =
-        objectMapper
-            .createObjectNode()
-            .put("dct:title", title)
-            .put("dct:description", "description")
-            .put("dct:creator", "creator")
-            .put("dct:issued", "2008-11-01T19:35:00.0000000Z")
-            .put("dcat:accessURL", "url");
-    obj.putArray("TerraDCAT_ap:hasDataCollection").addAll(List.of());
-    obj.putArray("prov:wasGeneratedBy").addAll(List.of());
-    obj.putArray("storage").addAll(List.of());
-    obj.putObject("counts");
-    obj.putArray("contributors").addAll(List.of());
-
-    return obj;
   }
 
   private UUID adminCreateDataset(CreateDatasetRequest request) throws Exception {

--- a/service/src/main/java/bio/terra/catalog/service/JsonValidationService.java
+++ b/service/src/main/java/bio/terra/catalog/service/JsonValidationService.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ResourceUtils;
 
 @Service
 public class JsonValidationService {
@@ -20,12 +21,12 @@ public class JsonValidationService {
 
   @Autowired
   public JsonValidationService(SchemaConfiguration schemaConfiguration) {
-    this.schema = getJsonSchemaFromFile(schemaConfiguration.basePath());
+    schema = getJsonSchemaFromFile(schemaConfiguration.basePath());
   }
 
   private JsonSchema getJsonSchemaFromFile(String file) {
     JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
-    try (var input = new FileInputStream(file)) {
+    try (var input = new FileInputStream(ResourceUtils.getFile(file))) {
       return factory.getSchema(input);
     } catch (IOException e) {
       throw new SchemaConfigurationException(e);

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -75,7 +75,7 @@ catalog:
     basePath: ${env.rawls.basePath}
 
   schema:
-    basePath: src/main/resources/schema/development/schema.json
+    basePath: classpath:schema/development/schema.json
 
 terra.common:
   kubernetes:

--- a/service/src/test/java/bio/terra/catalog/service/JsonValidationServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/JsonValidationServiceTest.java
@@ -8,10 +8,11 @@ import bio.terra.common.exception.BadRequestException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
-public class JsonValidationServiceTest {
-  private static final String BASE_PATH = "src/test/resources/schemas/test.schema.json";
+class JsonValidationServiceTest {
+  private static final String BASE_PATH = "classpath:schema/test.schema.json";
 
   private static final ObjectMapper objectMapper = new BeanConfig().objectMapper();
 
@@ -34,6 +35,7 @@ public class JsonValidationServiceTest {
     JsonValidationService service = new JsonValidationService(new SchemaConfiguration(BASE_PATH));
     ObjectNode json = objectMapper.createObjectNode();
     json.put("requiredField", "string");
+    json.put("dateField", Instant.now().toString());
     service.validateMetadata(json);
   }
 }

--- a/service/src/test/resources/schema/test.schema.json
+++ b/service/src/test/resources/schema/test.schema.json
@@ -1,12 +1,17 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Test Schema",
   "type": "object",
   "required": [
-    "requiredField"
+    "requiredField", "dateField"
   ],
   "properties": {
     "requiredField": {
       "type": "string"
+    },
+    "dateField": {
+      "type": "string",
+      "format": "date-time"
     },
     "nonRequiredField": {
       "type": "string"


### PR DESCRIPTION
Using a fixed file path works in the source tree but doesn't work in the .jar deployment. Changing to use a resource reference using `classpath:` should fix this.

Also
- generate a date-time value on the fly using `Instant`
- add an example of date-time to the test schema
- refactor duplicate code in integration tests that creates dataset metadata