### PR TITLE
DC-375: external datasets follow-on work

### DIFF
--- a/integration/src/main/java/scripts/testscripts/DatasetOperations.java
+++ b/integration/src/main/java/scripts/testscripts/DatasetOperations.java
@@ -109,6 +109,7 @@ public class DatasetOperations extends TestScript {
 
     crudUserJourney(client, StorageSystem.TDR, snapshotId.toString());
     crudUserJourney(client, StorageSystem.WKS, workspaceSource.getWorkspaceId());
+    crudUserJourney(client, StorageSystem.EXT, UUID.randomUUID().toString());
 
     previewUserJourney(StorageSystem.TDR, snapshotId.toString());
     previewUserJourney(StorageSystem.WKS, workspaceSource.getWorkspaceId());
@@ -239,7 +240,8 @@ public class DatasetOperations extends TestScript {
       Map<Object, Object> dataset = (Map<Object, Object>) datasetObj;
       if (dataset.get("id").equals(datasetId.toString())) {
         assertThat(dataset, hasEntry(is("dct:title"), is("crud")));
-        assertThat(dataset, hasEntry(is("accessLevel"), is("owner")));
+        String role = storageSystem == StorageSystem.EXT ? "discoverer" : "owner";
+        assertThat(dataset, hasEntry(is("accessLevel"), is(role)));
         if (storageSystem.equals(StorageSystem.TDR)) {
           assertThat(dataset, hasEntry(is("phsId"), is("1234")));
           assertTrue(dataset.containsKey("requestAccessURL"));

--- a/service/src/main/java/bio/terra/catalog/service/ExternalSystemService.java
+++ b/service/src/main/java/bio/terra/catalog/service/ExternalSystemService.java
@@ -1,5 +1,6 @@
 package bio.terra.catalog.service;
 
+import bio.terra.catalog.common.StorageSystem;
 import bio.terra.catalog.common.StorageSystemInformation;
 import bio.terra.catalog.common.StorageSystemService;
 import bio.terra.catalog.model.DatasetPreviewTable;
@@ -23,14 +24,11 @@ public class ExternalSystemService implements StorageSystemService {
 
   @Override
   public Map<String, StorageSystemInformation> getDatasets() {
-    // This can be implemented by returning the storage IDs for all EXT datasets in the database.
-    // Role is always DISCOVERER.
-
-    // query DB for all datasets that are external, make a map of ID to Discoverer access level
-    return datasetDao.listAllExternalDatasets().stream()
+    return datasetDao.listAllDatasets(StorageSystem.EXTERNAL).stream()
         .collect(
             Collectors.toMap(
                 Dataset::storageSourceId,
+                // For external datasets, the role is always DISCOVERER.
                 dataset -> new StorageSystemInformation(DatasetAccessLevel.DISCOVERER, null)));
   }
 

--- a/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
+++ b/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
@@ -136,9 +136,9 @@ public class DatasetDao {
   }
 
   @ReadTransaction
-  public List<Dataset> listAllExternalDatasets() {
+  public List<Dataset> listAllDatasets(StorageSystem storageSystem) {
     String sql = "SELECT * FROM dataset WHERE storage_system = :storageSystem";
-    var param = Map.of("storageSystem", String.valueOf(StorageSystem.EXTERNAL));
+    var param = Map.of("storageSystem", String.valueOf(storageSystem));
     return jdbcTemplate.query(sql, param, new DatasetMapper());
   }
 }

--- a/service/src/test/java/bio/terra/catalog/service/ExternalSystemServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/ExternalSystemServiceTest.java
@@ -22,10 +22,10 @@ class ExternalSystemServiceTest {
 
   @Test
   void getDatasets() {
-    String storageSourceId = "";
+    String storageSourceId = "source id";
     List<Dataset> resultDatasets =
         List.of(new Dataset(storageSourceId, StorageSystem.EXTERNAL, ""));
-    when(mockDatasetDao.listAllExternalDatasets()).thenReturn(resultDatasets);
+    when(mockDatasetDao.listAllDatasets(StorageSystem.EXTERNAL)).thenReturn(resultDatasets);
 
     var expectedStorageSystemInformation =
         new StorageSystemInformation(DatasetAccessLevel.DISCOVERER, null);

--- a/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
@@ -35,25 +35,19 @@ class DatasetDaoTest {
   }
 
   @Test
-  void testListAllDatasets() {
+  void testListAllExternalDatasets() {
     String storageSourceId = UUID.randomUUID().toString();
     for (StorageSystem value : StorageSystem.values()) {
       createDataset(storageSourceId, value);
     }
-
-    List<Dataset> onlyExternal =
+    List<Dataset> datasets =
         datasetDao.listAllDatasets(StorageSystem.EXTERNAL).stream()
             .filter(dataset -> dataset.storageSourceId().equals(storageSourceId))
             .toList();
-    assertThat(onlyExternal, hasSize(1));
-    assertThat(onlyExternal.get(0).storageSystem(), is(StorageSystem.EXTERNAL));
-
-    List<Dataset> allDatasets =
-        datasetDao.listAllDatasets().stream()
-            .filter(dataset -> dataset.storageSourceId().equals(storageSourceId))
-            .toList();
-    assertThat(allDatasets, hasSize(StorageSystem.values().length));
-    allDatasets.forEach(dataset -> assertThat(dataset.storageSourceId(), is(storageSourceId)));
+    assertThat(datasets, hasSize(1));
+    Dataset dataset = datasets.get(0);
+    assertThat(dataset.storageSourceId(), is(storageSourceId));
+    assertThat(dataset.storageSystem(), is(StorageSystem.EXTERNAL));
   }
 
   @Test
@@ -67,6 +61,19 @@ class DatasetDaoTest {
     assertEquals(newMetadata, datasetDao.retrieve(id).metadata());
     assertTrue(datasetDao.delete(dataset));
     assertThrows(DatasetNotFoundException.class, () -> datasetDao.retrieve(id));
+  }
+
+  @Test
+  void testCreateDatasetWithDifferentSources() {
+    String storageSourceId = UUID.randomUUID().toString();
+    for (StorageSystem value : StorageSystem.values()) {
+      createDataset(storageSourceId, value);
+    }
+    List<Dataset> datasets =
+        datasetDao.listAllDatasets().stream()
+            .filter(dataset -> dataset.storageSourceId().equals(storageSourceId)).toList();
+    assertThat(datasets, hasSize(StorageSystem.values().length));
+    datasets.forEach(dataset -> assertThat(dataset.storageSourceId(), is(storageSourceId)));
   }
 
   @Test

--- a/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
@@ -71,7 +71,8 @@ class DatasetDaoTest {
     }
     List<Dataset> datasets =
         datasetDao.listAllDatasets().stream()
-            .filter(dataset -> dataset.storageSourceId().equals(storageSourceId)).toList();
+            .filter(dataset -> dataset.storageSourceId().equals(storageSourceId))
+            .toList();
     assertThat(datasets, hasSize(StorageSystem.values().length));
     datasets.forEach(dataset -> assertThat(dataset.storageSourceId(), is(storageSourceId)));
   }

--- a/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
@@ -3,6 +3,8 @@ package bio.terra.catalog.service.dataset;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -13,7 +15,6 @@ import bio.terra.catalog.service.dataset.exception.DatasetNotFoundException;
 import bio.terra.catalog.service.dataset.exception.InvalidDatasetException;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,52 +30,43 @@ class DatasetDaoTest {
       """
           {"sampleId": "12345", "species": ["mouse", "human"]}""";
 
-  private Dataset createDataset(String storageSourceId, StorageSystem storageSystem)
-      throws InvalidDatasetException {
-    Dataset dataset =
-        new Dataset(null, storageSourceId, storageSystem, DatasetDaoTest.METADATA, null);
-    return datasetDao.create(dataset);
+  private Dataset createDataset(String storageSourceId, StorageSystem storageSystem) {
+    return datasetDao.create(new Dataset(storageSourceId, storageSystem, DatasetDaoTest.METADATA));
   }
 
   @Test
-  void testListAllExternalDatasets() {
-    String sourceId = "";
+  void testListAllDatasets() {
+    String storageSourceId = UUID.randomUUID().toString();
     for (StorageSystem value : StorageSystem.values()) {
-      createDataset(sourceId, value);
+      createDataset(storageSourceId, value);
     }
 
-    List<Dataset> result =
-        datasetDao.listAllExternalDatasets().stream()
-            .filter(dataset -> dataset.storageSourceId().equals(sourceId))
-            .collect(Collectors.toList());
-    assertEquals(1, result.size());
-    assertEquals(result.get(0).storageSystem(), StorageSystem.EXTERNAL);
+    List<Dataset> onlyExternal =
+        datasetDao.listAllDatasets(StorageSystem.EXTERNAL).stream()
+            .filter(dataset -> dataset.storageSourceId().equals(storageSourceId))
+            .toList();
+    assertThat(onlyExternal, hasSize(1));
+    assertThat(onlyExternal.get(0).storageSystem(), is(StorageSystem.EXTERNAL));
+
+    List<Dataset> allDatasets =
+        datasetDao.listAllDatasets().stream()
+            .filter(dataset -> dataset.storageSourceId().equals(storageSourceId))
+            .toList();
+    assertThat(allDatasets, hasSize(StorageSystem.values().length));
+    allDatasets.forEach(dataset -> assertThat(dataset.storageSourceId(), is(storageSourceId)));
   }
 
   @Test
   void testDatasetCrudOperations() {
     String storageSourceId = UUID.randomUUID().toString();
     Dataset dataset = createDataset(storageSourceId, StorageSystem.TERRA_DATA_REPO);
+    var newMetadata = "{}";
+    Dataset updateRequest = dataset.withMetadata(newMetadata);
+    datasetDao.update(updateRequest);
     DatasetId id = dataset.id();
-    Dataset updateRequest =
-        new Dataset(id, storageSourceId, StorageSystem.TERRA_WORKSPACE, METADATA, null);
-    datasetDao.retrieve(id);
-    Dataset updatedDataset = datasetDao.update(updateRequest);
-    assertEquals(updatedDataset.storageSystem(), updateRequest.storageSystem());
+    assertEquals(newMetadata, datasetDao.retrieve(id).metadata());
     assertTrue(datasetDao.delete(dataset));
     assertThrows(DatasetNotFoundException.class, () -> datasetDao.retrieve(id));
-  }
-
-  @Test
-  void testCreateDatasetWithDifferentSources() {
-    String storageSourceId = UUID.randomUUID().toString();
-    createDataset(storageSourceId, StorageSystem.TERRA_DATA_REPO);
-    createDataset(storageSourceId, StorageSystem.TERRA_WORKSPACE);
-    long datasetCount =
-        datasetDao.listAllDatasets().stream()
-            .filter(dataset -> dataset.storageSourceId().equals(storageSourceId))
-            .count();
-    assertEquals(2L, datasetCount);
   }
 
   @Test
@@ -89,9 +81,7 @@ class DatasetDaoTest {
   @Test
   void testHandleNonExistentDatasets() {
     DatasetId id = new DatasetId(UUID.randomUUID());
-    String storageSourceId = UUID.randomUUID().toString();
-    Dataset dataset =
-        new Dataset(id, storageSourceId, StorageSystem.TERRA_WORKSPACE, METADATA, null);
+    Dataset dataset = new Dataset(id, "source id", StorageSystem.TERRA_WORKSPACE, METADATA, null);
     assertThrows(DatasetNotFoundException.class, () -> datasetDao.retrieve(id));
     assertThrows(DatasetNotFoundException.class, () -> datasetDao.update(dataset));
     assertFalse(datasetDao.delete(dataset));
@@ -99,10 +89,12 @@ class DatasetDaoTest {
 
   @Test
   void testFind() {
-    Dataset d1 = createDataset("id1", StorageSystem.TERRA_DATA_REPO);
+    String storageSourceId = UUID.randomUUID().toString();
+    Dataset d1 = createDataset(storageSourceId, StorageSystem.TERRA_DATA_REPO);
     // Create a TDR dataset that we don't request in the query below.
-    createDataset("id2", StorageSystem.TERRA_DATA_REPO);
-    Dataset d3 = createDataset("id3", StorageSystem.EXTERNAL);
+    String storageSourceId2 = UUID.randomUUID().toString();
+    createDataset(storageSourceId2, StorageSystem.TERRA_DATA_REPO);
+    Dataset d3 = createDataset(storageSourceId, StorageSystem.EXTERNAL);
     var datasets =
         datasetDao.find(
             StorageSystem.TERRA_DATA_REPO, List.of(d1.storageSourceId(), d3.storageSourceId()));


### PR DESCRIPTION
- add integration CRUD test for external datasets
- update DAO integration tests to use random IDs to avoid test collisions in shared databases like `dev`
- other misc minor changes