### PR TITLE
DC-574: Look at how we return 401 vs 403 errors and fix if necessary

### DIFF
--- a/integration/src/main/java/scripts/testscripts/DatasetPermissionOperations.java
+++ b/integration/src/main/java/scripts/testscripts/DatasetPermissionOperations.java
@@ -123,8 +123,7 @@ public class DatasetPermissionOperations extends TestScript {
     // note if this assertion fails we'll leave behind a stray dataset in the db
     assertThrows(ApiException.class, () -> userDatasetsApi.createDataset(request));
     assertThat(
-        userDatasetsApi.getApiClient().getStatusCode(),
-        is(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED));
+        userDatasetsApi.getApiClient().getStatusCode(), is(HttpStatusCodes.STATUS_CODE_FORBIDDEN));
 
     // verify the user can still access data though
     userDatasetsApi.getDataset(adminDatasetId);
@@ -159,8 +158,7 @@ public class DatasetPermissionOperations extends TestScript {
     // note if this assertion fails we'll leave behind a stray dataset in the db
     assertThrows(ApiException.class, () -> userDatasetsApi.createDataset(request));
     assertThat(
-        userDatasetsApi.getApiClient().getStatusCode(),
-        is(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED));
+        userDatasetsApi.getApiClient().getStatusCode(), is(HttpStatusCodes.STATUS_CODE_FORBIDDEN));
 
     // verify the user cannot preview data either
     assertThrows(
@@ -177,8 +175,7 @@ public class DatasetPermissionOperations extends TestScript {
   private void testNoPermissionsForSnapshotDataset() throws Exception {
     clearTestSnapshotPermissions();
     // verify the user cannot access dataset without any permissions
-    assertNoPermissionsOnDataset(
-        adminTestSnapshotDatasetId, HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
+    assertNoPermissionsOnDataset(adminTestSnapshotDatasetId, HttpStatusCodes.STATUS_CODE_FORBIDDEN);
   }
 
   private void testAdminPermissionsOnUserSnapshot() throws Exception {

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -15,7 +15,7 @@ import bio.terra.catalog.service.dataset.DatasetAccessLevel;
 import bio.terra.catalog.service.dataset.DatasetDao;
 import bio.terra.catalog.service.dataset.DatasetId;
 import bio.terra.common.exception.BadRequestException;
-import bio.terra.common.exception.UnauthorizedException;
+import bio.terra.common.exception.ForbiddenException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -172,7 +172,7 @@ public class DatasetService {
     // catalog entry.
     if (!samService.hasGlobalAction(action)
         && !getService(dataset).getRole(dataset.storageSourceId()).hasAction(action)) {
-      throw new UnauthorizedException(String.format("User does not have permission to %s", action));
+      throw new ForbiddenException(String.format("User does not have permission to %s", action));
     }
   }
 

--- a/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -25,7 +25,7 @@ import bio.terra.catalog.service.dataset.DatasetAccessLevel;
 import bio.terra.catalog.service.dataset.DatasetDao;
 import bio.terra.catalog.service.dataset.DatasetId;
 import bio.terra.common.exception.BadRequestException;
-import bio.terra.common.exception.UnauthorizedException;
+import bio.terra.common.exception.ForbiddenException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -200,7 +200,7 @@ class DatasetServiceTest {
     mockDataset();
     when(externalSystemService.getRole(dataset.storageSourceId()))
         .thenReturn(DatasetAccessLevel.NO_ACCESS);
-    assertThrows(UnauthorizedException.class, () -> datasetService.deleteMetadata(datasetId));
+    assertThrows(ForbiddenException.class, () -> datasetService.deleteMetadata(datasetId));
   }
 
   @Test()
@@ -215,7 +215,7 @@ class DatasetServiceTest {
   void testDeleteMetadataNoPermission() {
     mockDataset();
     when(externalSystemService.getRole(SOURCE_ID)).thenReturn(DatasetAccessLevel.READER);
-    assertThrows(UnauthorizedException.class, () -> datasetService.deleteMetadata(datasetId));
+    assertThrows(ForbiddenException.class, () -> datasetService.deleteMetadata(datasetId));
   }
 
   @Test
@@ -223,7 +223,7 @@ class DatasetServiceTest {
     mockDataset();
     when(externalSystemService.getRole(dataset.storageSourceId()))
         .thenReturn(DatasetAccessLevel.NO_ACCESS);
-    assertThrows(UnauthorizedException.class, () -> datasetService.getMetadata(datasetId));
+    assertThrows(ForbiddenException.class, () -> datasetService.getMetadata(datasetId));
   }
 
   @Test
@@ -239,7 +239,7 @@ class DatasetServiceTest {
     when(externalSystemService.getRole(dataset.storageSourceId()))
         .thenReturn(DatasetAccessLevel.NO_ACCESS);
     assertThrows(
-        UnauthorizedException.class, () -> datasetService.updateMetadata(datasetId, METADATA));
+        ForbiddenException.class, () -> datasetService.updateMetadata(datasetId, METADATA));
   }
 
   @Test
@@ -263,7 +263,7 @@ class DatasetServiceTest {
   void testCreateDatasetWithInvalidUser() {
     when(datarepoService.getRole(null)).thenReturn(DatasetAccessLevel.DISCOVERER);
     assertThrows(
-        UnauthorizedException.class,
+        ForbiddenException.class,
         () -> datasetService.createDataset(StorageSystem.TERRA_DATA_REPO, null, METADATA));
   }
 

--- a/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -250,8 +250,7 @@ class DatasetServiceTest {
     when(datarepoService.getRole(null)).thenReturn(DatasetAccessLevel.DISCOVERER);
     assertThrows(
         ForbiddenException.class,
-        () -> datasetService.createDataset(StorageSystem.TERRA_DATA_REPO, null, METADATA));
-
+        () -> datasetService.upsertDataset(StorageSystem.TERRA_DATA_REPO, null, METADATA));
   }
 
   @Test


### PR DESCRIPTION
changed the `UnauthorizedException` to a `ForbiddenException` in the `ensureActionPermission` method