### PR TITLE
[DC-420] Multithread storage system dataset fetching

### DIFF
--- a/service/src/main/java/bio/terra/catalog/controller/DatasetApiController.java
+++ b/service/src/main/java/bio/terra/catalog/controller/DatasetApiController.java
@@ -10,6 +10,7 @@ import bio.terra.catalog.model.DatasetPreviewTablesResponse;
 import bio.terra.catalog.model.DatasetsListResponse;
 import bio.terra.catalog.service.DatasetService;
 import bio.terra.catalog.service.dataset.DatasetId;
+import bio.terra.common.exception.ApiException;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.CacheControl;
@@ -27,9 +28,13 @@ public class DatasetApiController implements DatasetsApi {
 
   @Override
   public ResponseEntity<DatasetsListResponse> listDatasets() {
-    return ResponseEntity.ok()
-        .cacheControl(CacheControl.noStore())
-        .body(datasetService.listDatasets());
+    try {
+      return ResponseEntity.ok()
+          .cacheControl(CacheControl.noStore())
+          .body(datasetService.listDatasets());
+    } catch (InterruptedException e) {
+      throw new ApiException("Request timeout", e);
+    }
   }
 
   @Override

--- a/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -104,7 +104,7 @@ class DatasetServiceTest {
   }
 
   @Test
-  void listDatasets() {
+  void listDatasets() throws Exception {
     var workspaces = Map.of(WORKSPACE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER));
     var idToRole = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER));
     when(datarepoService.getDatasets()).thenReturn(idToRole);
@@ -135,7 +135,7 @@ class DatasetServiceTest {
   }
 
   @Test
-  void listDatasetsWithPhsId() {
+  void listDatasetsWithPhsId() throws Exception {
     String phsId = "1234";
     var idToRole = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER, phsId));
     when(datarepoService.getDatasets()).thenReturn(idToRole);
@@ -148,7 +148,7 @@ class DatasetServiceTest {
   }
 
   @Test
-  void listDatasetsWithPhsIdOverride() {
+  void listDatasetsWithPhsIdOverride() throws Exception {
     String phsId = "1234";
     var idToRole = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER, phsId));
     when(datarepoService.getDatasets()).thenReturn(idToRole);
@@ -167,7 +167,7 @@ class DatasetServiceTest {
   }
 
   @Test
-  void listDatasetsUsingAdminPermissions() {
+  void listDatasetsUsingAdminPermissions() throws Exception {
     Map<String, StorageSystemInformation> workspaces = Map.of();
     var datasets = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER));
     when(datarepoService.getDatasets()).thenReturn(datasets);


### PR DESCRIPTION
Before:
curl -X 'GET' 'localhost:8080/api/v1/datasets' -H 'accept: application/json'   0.01s user 0.01s system 1% cpu 1.451 total

After:
curl -X 'GET' 'localhost:8080/api/v1/datasets' -H 'accept: application/json'   0.01s user 0.02s system 7% cpu 0.292 total

This is round one of performance improvements. The next planned change is to do all the database fetching at once, rather than do a separate dao call per storage system.