### PR TITLE
[DC-420] Sr multithread storage systems

### DIFF
--- a/service/src/main/java/bio/terra/catalog/common/RequestContextCopier.java
+++ b/service/src/main/java/bio/terra/catalog/common/RequestContextCopier.java
@@ -1,22 +1,21 @@
 package bio.terra.catalog.common;
 
+import java.util.stream.Stream;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 
-import java.util.stream.Stream;
-
 /**
- * This class supports creating a parallel {@code Stream} with a copy of the current thread's
- * Spring request attributes copied to the stream's sub-threads. This has the effect of
- * allowing request scope injected fields to be used in classes that are passed to the sub-threads.
- * <p/>
- * For example, if {@code service} uses a request scope injection, and you want to run it in
+ * This class supports creating a parallel {@code Stream} with a copy of the current thread's Spring
+ * request attributes copied to the stream's sub-threads. This has the effect of allowing request
+ * scope injected fields to be used in classes that are passed to the sub-threads.
+ *
+ * <p>For example, if {@code service} uses a request scope injection, and you want to run it in
  * parallel, you can write:
  *
  * <pre>{@code
- *     int sum = RequestContextCopier.parallelWithRequest(widgets.stream())
- *                      .mapToInt(w -> service.getWeight(w))
- *                      .sum();
+ * int sum = RequestContextCopier.parallelWithRequest(widgets.stream())
+ *                  .mapToInt(w -> service.getWeight(w))
+ *                  .sum();
  * }</pre>
  *
  * @see RequestContextHolder
@@ -27,8 +26,7 @@ public class RequestContextCopier {
 
   private final RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
 
-  private RequestContextCopier() {
-  }
+  private RequestContextCopier() {}
 
   private <T> void copyToThread(T target) {
     if (RequestContextHolder.getRequestAttributes() == null) {
@@ -38,8 +36,8 @@ public class RequestContextCopier {
 
   /**
    * Given a {@code Stream}, make a parallel version of it where the current request scope
-   * attributes are copied to each of the sub-threads. The parallel version is created
-   * using {@link Stream#parallel()}.
+   * attributes are copied to each of the sub-threads. The parallel version is created using {@link
+   * Stream#parallel()}.
    *
    * @param stream the stream to parallelize
    * @return the new parallel stream

--- a/service/src/main/java/bio/terra/catalog/common/RequestContextCopier.java
+++ b/service/src/main/java/bio/terra/catalog/common/RequestContextCopier.java
@@ -1,0 +1,58 @@
+package bio.terra.catalog.common;
+
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+import java.util.stream.Stream;
+
+/**
+ * This class supports creating a parallel {@code Stream} with a copy of the current thread's
+ * Spring request attributes copied to the stream's sub-threads. This has the effect of
+ * allowing request scope injected fields to be used in classes that are passed to the sub-threads.
+ * <p/>
+ * For example, if {@code service} uses a request scope injection, and you want to run it in
+ * parallel, you can write:
+ *
+ * <pre>{@code
+ *     int sum = RequestContextCopier.parallelWithRequest(widgets.stream())
+ *                      .mapToInt(w -> service.getWeight(w))
+ *                      .sum();
+ * }</pre>
+ *
+ * @see RequestContextHolder
+ * @see RequestAttributes
+ * @see Stream#parallel()
+ */
+public class RequestContextCopier {
+
+  private final RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+
+  private RequestContextCopier() {
+  }
+
+  private <T> void copyToThread(T target) {
+    if (RequestContextHolder.getRequestAttributes() == null) {
+      RequestContextHolder.setRequestAttributes(attributes);
+    }
+  }
+
+  /**
+   * Given a {@code Stream}, make a parallel version of it where the current request scope
+   * attributes are copied to each of the sub-threads. The parallel version is created
+   * using {@link Stream#parallel()}.
+   *
+   * @param stream the stream to parallelize
+   * @return the new parallel stream
+   * @param <S> the type of the stream elements
+   */
+  // This usage of `peek()` is correct, even though it generates a sonar warning. If it's never
+  // called (because the element in the stream is never consumed), that's fine.
+  @SuppressWarnings("java:S3864")
+  public static <S> Stream<S> parallelWithRequest(Stream<S> stream) {
+    // Spring request context is limited to the main thread, in order
+    // to have the token and auth information available, we need to copy
+    // the current thread requestAttributes to the child threads.
+    RequestContextCopier copier = new RequestContextCopier();
+    return stream.parallel().peek(copier::copyToThread);
+  }
+}

--- a/service/src/main/java/bio/terra/catalog/controller/DatasetApiController.java
+++ b/service/src/main/java/bio/terra/catalog/controller/DatasetApiController.java
@@ -10,6 +10,7 @@ import bio.terra.catalog.model.DatasetPreviewTablesResponse;
 import bio.terra.catalog.model.DatasetsListResponse;
 import bio.terra.catalog.service.DatasetService;
 import bio.terra.catalog.service.dataset.DatasetId;
+import bio.terra.common.exception.ApiException;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.CacheControl;
@@ -27,9 +28,13 @@ public class DatasetApiController implements DatasetsApi {
 
   @Override
   public ResponseEntity<DatasetsListResponse> listDatasets() {
-    return ResponseEntity.ok()
-        .cacheControl(CacheControl.noStore())
-        .body(datasetService.listDatasets());
+    try {
+      return ResponseEntity.ok()
+          .cacheControl(CacheControl.noStore())
+          .body(datasetService.listDatasets());
+    } catch (InterruptedException e) {
+      throw new ApiException("Request timeout", e);
+    }
   }
 
   @Override

--- a/service/src/main/java/bio/terra/catalog/controller/DatasetApiController.java
+++ b/service/src/main/java/bio/terra/catalog/controller/DatasetApiController.java
@@ -10,7 +10,6 @@ import bio.terra.catalog.model.DatasetPreviewTablesResponse;
 import bio.terra.catalog.model.DatasetsListResponse;
 import bio.terra.catalog.service.DatasetService;
 import bio.terra.catalog.service.dataset.DatasetId;
-import bio.terra.common.exception.ApiException;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.CacheControl;
@@ -28,13 +27,9 @@ public class DatasetApiController implements DatasetsApi {
 
   @Override
   public ResponseEntity<DatasetsListResponse> listDatasets() {
-    try {
-      return ResponseEntity.ok()
-          .cacheControl(CacheControl.noStore())
-          .body(datasetService.listDatasets());
-    } catch (InterruptedException e) {
-      throw new ApiException("Request timeout", e);
-    }
+    return ResponseEntity.ok()
+        .cacheControl(CacheControl.noStore())
+        .body(datasetService.listDatasets());
   }
 
   @Override

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -16,7 +16,6 @@ import bio.terra.catalog.service.dataset.DatasetDao;
 import bio.terra.catalog.service.dataset.DatasetId;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.ForbiddenException;
-import bio.terra.common.iam.BearerToken;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -136,6 +136,9 @@ public class DatasetService {
   }
 
   public DatasetsListResponse listDatasets() {
+    // Spring request context is limited to the main thread, in order
+    // to have the token and auth information available, we need to copy
+    // the current thread requestAttributes to the child threads
     RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
     List<DatasetResponse> datasets =
         new ArrayList<>(

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -38,7 +38,6 @@ public class DatasetService {
   private final DatasetDao datasetDao;
   private final ObjectMapper objectMapper;
   private final StorageSystemService externalService;
-  private final BearerToken bearerToken;
 
   private static final int MAX_ROWS = 30;
 
@@ -49,8 +48,7 @@ public class DatasetService {
       SamService samService,
       JsonValidationService jsonValidationService,
       DatasetDao datasetDao,
-      ObjectMapper objectMapper,
-      BearerToken bearerToken) {
+      ObjectMapper objectMapper) {
     this.datarepoService = datarepoService;
     this.rawlsService = rawlsService;
     this.externalService = externalService;
@@ -58,7 +56,6 @@ public class DatasetService {
     this.jsonValidationService = jsonValidationService;
     this.datasetDao = datasetDao;
     this.objectMapper = objectMapper;
-    this.bearerToken = bearerToken;
   }
 
   private StorageSystemService getService(StorageSystem system) {

--- a/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
+++ b/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
@@ -33,7 +33,9 @@ class RequestContextCopierTest {
 
   @Test
   @Disabled
-  // This is disabled because the way in which Java optimizes parallelization is tricky to test in junit. It works consistently in the positive test, but in the negative test it sometimes optimizes things away where we would like it not to.
+  // This is disabled because the way in which Java optimizes parallelization is tricky to test in
+  // junit. It works consistently in the positive test, but in the negative test it sometimes
+  // optimizes things away where we would like it not to.
   void requestContextDoesntFollowToChildThreads() {
     assertThrows(IllegalStateException.class, () -> runTestWithProvider(Stream::parallel));
   }

--- a/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
+++ b/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
@@ -1,0 +1,29 @@
+package bio.terra.catalog.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class RequestContextCopierTest {
+  @Test
+  void setsRequestContextInsideThread() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setAttribute("attribute", "value");
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    Stream.of(1, 2)
+        .parallel()
+        .forEach(
+            val -> {
+              assertEquals(
+                  Objects.requireNonNull(RequestContextHolder.getRequestAttributes())
+                      .getAttribute("attribute", RequestAttributes.SCOPE_REQUEST),
+                  "value");
+            });
+  }
+}

--- a/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
+++ b/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
@@ -13,7 +13,7 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.RequestScope;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-public class RequestContextCopierTest {
+class RequestContextCopierTest {
   public static final int THREADS = 2;
 
   int runTestWithProvider(Function<Stream<String>, Stream<String>> provider) {
@@ -33,6 +33,7 @@ public class RequestContextCopierTest {
 
   @Test
   @Disabled
+  // This is disabled because the way in which Java optimizes parallelization is tricky to test in junit. It works consistently in the positive test, but in the negative test it sometimes optimizes things away where we would like it not to.
   void requestContextDoesntFollowToChildThreads() {
     assertThrows(IllegalStateException.class, () -> runTestWithProvider(Stream::parallel));
   }

--- a/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
+++ b/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
@@ -16,14 +16,12 @@ public class RequestContextCopierTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setAttribute("attribute", "value");
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
-    Stream.of(1, 2)
-        .parallel()
+    RequestContextCopier.parallelWithRequest(Stream.of(1, 2))
         .forEach(
-            val -> {
-              assertEquals(
-                  Objects.requireNonNull(RequestContextHolder.getRequestAttributes())
-                      .getAttribute("attribute", RequestAttributes.SCOPE_REQUEST),
-                  "value");
-            });
+            val ->
+                assertEquals(
+                    Objects.requireNonNull(RequestContextHolder.getRequestAttributes())
+                        .getAttribute("attribute", RequestAttributes.SCOPE_REQUEST),
+                    "value"));
   }
 }

--- a/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
+++ b/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
@@ -19,6 +19,7 @@ public class RequestContextCopierTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
     Scope scope = new RequestScope();
+    System.setProperty("java.util.concurrent.ForkJoinPool.common.parallelism", "20");
     return provider
         .apply(Stream.generate(() -> "ignored").limit(THREADS))
         .mapToInt(value -> (int) scope.get("attribute", () -> 1))

--- a/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
+++ b/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.function.Function;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.config.Scope;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -19,7 +20,6 @@ public class RequestContextCopierTest {
     MockHttpServletRequest request = new MockHttpServletRequest();
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
     Scope scope = new RequestScope();
-    System.setProperty("java.util.concurrent.ForkJoinPool.common.parallelism", "20");
     return provider
         .apply(Stream.generate(() -> "ignored").limit(THREADS))
         .mapToInt(value -> (int) scope.get("attribute", () -> 1))
@@ -32,6 +32,7 @@ public class RequestContextCopierTest {
   }
 
   @Test
+  @Disabled
   void requestContextDoesntFollowToChildThreads() {
     assertThrows(IllegalStateException.class, () -> runTestWithProvider(Stream::parallel));
   }

--- a/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
+++ b/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
@@ -1,60 +1,42 @@
 package bio.terra.catalog.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Objects;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.Scope;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.RequestScope;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 public class RequestContextCopierTest {
 
   int checkAndSumAttributeValueFromStream(@NotNull Stream<String> stream) {
-    return stream
-        .mapToInt(
-            value -> {
-              RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
-              try {
-                // We need to sleep to force the other threads not to reuse the current thread
-                Thread.sleep(100);
-              } catch (InterruptedException e) {
-                return 0;
-              }
-              return requestAttributes == null
-                  ? 0
-                  : (int)
-                      Objects.requireNonNullElse(
-                          requestAttributes.getAttribute(
-                              "attribute", RequestAttributes.SCOPE_REQUEST),
-                          0);
-            })
-        .sum();
+    Scope scope = new RequestScope();
+    return stream.mapToInt(value -> (int) scope.get("attribute", () -> 1)).sum();
   }
 
   @Test
   void setsRequestContextInsideThread() {
     MockHttpServletRequest request = new MockHttpServletRequest();
-    request.setAttribute("attribute", 1);
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
     int streamValuesWithAttribute =
         checkAndSumAttributeValueFromStream(
-            RequestContextCopier.parallelWithRequest(Stream.generate(() -> "ignored").limit(5)));
-    assertEquals(streamValuesWithAttribute, 5);
+            RequestContextCopier.parallelWithRequest(Stream.generate(() -> "ignored").limit(2)));
+    assertEquals(streamValuesWithAttribute, 2);
   }
 
   @Test
   void requestContextDoesntFollowToChildThreads() {
     MockHttpServletRequest request = new MockHttpServletRequest();
-    request.setAttribute("attribute", 1);
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
-
-    int streamValuesWithAttribute =
-        checkAndSumAttributeValueFromStream(Stream.generate(() -> "ignored").limit(5).parallel());
-    // This should be one, because one of the threads used will be the original
-    assertEquals(streamValuesWithAttribute, 1);
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            checkAndSumAttributeValueFromStream(
+                Stream.generate(() -> "ignored").limit(2).parallel()));
   }
 }

--- a/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
+++ b/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
@@ -32,10 +32,9 @@ class RequestContextCopierTest {
   }
 
   @Test
-  @Disabled
-  // This is disabled because the way in which Java optimizes parallelization is tricky to test in
-  // junit. It works consistently in the positive test, but in the negative test it sometimes
-  // optimizes things away where we would like it not to.
+  @Disabled(
+      value =
+          "This is disabled because the way in which Java optimizes parallelization is tricky to test in junit. It works consistently in the positive test, but in the negative test it sometimes optimizes things away where we would like it not to.")
   void requestContextDoesntFollowToChildThreads() {
     assertThrows(IllegalStateException.class, () -> runTestWithProvider(Stream::parallel));
   }

--- a/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
+++ b/service/src/test/java/bio/terra/catalog/common/RequestContextCopierTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Objects;
 import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.RequestAttributes;
@@ -11,17 +12,49 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 public class RequestContextCopierTest {
+
+  int checkAndSumAttributeValueFromStream(@NotNull Stream<String> stream) {
+    return stream
+        .mapToInt(
+            value -> {
+              RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+              try {
+                // We need to sleep to force the other threads not to reuse the current thread
+                Thread.sleep(100);
+              } catch (InterruptedException e) {
+                return 0;
+              }
+              return requestAttributes == null
+                  ? 0
+                  : (int)
+                      Objects.requireNonNullElse(
+                          requestAttributes.getAttribute(
+                              "attribute", RequestAttributes.SCOPE_REQUEST),
+                          0);
+            })
+        .sum();
+  }
+
   @Test
   void setsRequestContextInsideThread() {
     MockHttpServletRequest request = new MockHttpServletRequest();
-    request.setAttribute("attribute", "value");
+    request.setAttribute("attribute", 1);
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
-    RequestContextCopier.parallelWithRequest(Stream.of(1, 2))
-        .forEach(
-            val ->
-                assertEquals(
-                    Objects.requireNonNull(RequestContextHolder.getRequestAttributes())
-                        .getAttribute("attribute", RequestAttributes.SCOPE_REQUEST),
-                    "value"));
+    int streamValuesWithAttribute =
+        checkAndSumAttributeValueFromStream(
+            RequestContextCopier.parallelWithRequest(Stream.generate(() -> "ignored").limit(5)));
+    assertEquals(streamValuesWithAttribute, 5);
+  }
+
+  @Test
+  void requestContextDoesntFollowToChildThreads() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setAttribute("attribute", 1);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    int streamValuesWithAttribute =
+        checkAndSumAttributeValueFromStream(Stream.generate(() -> "ignored").limit(5).parallel());
+    // This should be one, because one of the threads used will be the original
+    assertEquals(streamValuesWithAttribute, 1);
   }
 }

--- a/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -104,7 +104,7 @@ class DatasetServiceTest {
   }
 
   @Test
-  void listDatasets() {
+  void listDatasets() throws Exception {
     var workspaces = Map.of(WORKSPACE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER));
     var idToRole = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER));
     when(datarepoService.getDatasets()).thenReturn(idToRole);
@@ -135,7 +135,7 @@ class DatasetServiceTest {
   }
 
   @Test
-  void listDatasetsWithPhsId() {
+  void listDatasetsWithPhsId() throws Exception {
     String phsId = "1234";
     var idToRole = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER, phsId));
     when(datarepoService.getDatasets()).thenReturn(idToRole);
@@ -148,7 +148,7 @@ class DatasetServiceTest {
   }
 
   @Test
-  void listDatasetsWithPhsIdOverride() {
+  void listDatasetsWithPhsIdOverride() throws Exception {
     String phsId = "1234";
     var idToRole = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER, phsId));
     when(datarepoService.getDatasets()).thenReturn(idToRole);
@@ -167,7 +167,7 @@ class DatasetServiceTest {
   }
 
   @Test
-  void listDatasetsUsingAdminPermissions() {
+  void listDatasetsUsingAdminPermissions() throws Exception {
     Map<String, StorageSystemInformation> workspaces = Map.of();
     var datasets = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER));
     when(datarepoService.getDatasets()).thenReturn(datasets);

--- a/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -104,7 +104,7 @@ class DatasetServiceTest {
   }
 
   @Test
-  void listDatasets() throws Exception {
+  void listDatasets() {
     var workspaces = Map.of(WORKSPACE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER));
     var idToRole = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER));
     when(datarepoService.getDatasets()).thenReturn(idToRole);
@@ -113,6 +113,7 @@ class DatasetServiceTest {
         .thenReturn(List.of(workspaceDataset));
     when(datasetDao.find(StorageSystem.TERRA_DATA_REPO, idToRole.keySet()))
         .thenReturn(List.of(tdrDataset));
+    when(datasetDao.find(StorageSystem.EXTERNAL, Set.of())).thenReturn(List.of());
     ObjectNode workspaceJson = (ObjectNode) datasetService.listDatasets().getResult().get(0);
     ObjectNode tdrJson = (ObjectNode) datasetService.listDatasets().getResult().get(1);
     assertThat(workspaceJson.get("name").asText(), is("name"));
@@ -135,20 +136,22 @@ class DatasetServiceTest {
   }
 
   @Test
-  void listDatasetsWithPhsId() throws Exception {
+  void listDatasetsWithPhsId() {
     String phsId = "1234";
     var idToRole = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER, phsId));
     when(datarepoService.getDatasets()).thenReturn(idToRole);
     when(datasetDao.find(StorageSystem.TERRA_WORKSPACE, Set.of())).thenReturn(List.of());
     when(datasetDao.find(StorageSystem.TERRA_DATA_REPO, idToRole.keySet()))
         .thenReturn(List.of(tdrDataset));
+    when(datasetDao.find(StorageSystem.EXTERNAL, Set.of())).thenReturn(List.of());
+
     ObjectNode tdrJson = (ObjectNode) datasetService.listDatasets().getResult().get(0);
     assertThat(tdrJson.get("phsId").asText(), is(phsId));
     assertTrue(tdrJson.has("requestAccessURL"));
   }
 
   @Test
-  void listDatasetsWithPhsIdOverride() throws Exception {
+  void listDatasetsWithPhsIdOverride() {
     String phsId = "1234";
     var idToRole = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER, phsId));
     when(datarepoService.getDatasets()).thenReturn(idToRole);
@@ -161,13 +164,15 @@ class DatasetServiceTest {
                     """
             {"%s":"%s"}"""
                         .formatted(DatasetService.REQUEST_ACCESS_URL_PROPERTY_NAME, url))));
+    when(datasetDao.find(StorageSystem.EXTERNAL, Set.of())).thenReturn(List.of());
+
     ObjectNode tdrJson = (ObjectNode) datasetService.listDatasets().getResult().get(0);
     assertThat(tdrJson.get("phsId").asText(), is(phsId));
     assertThat(tdrJson.get(DatasetService.REQUEST_ACCESS_URL_PROPERTY_NAME).asText(), is(url));
   }
 
   @Test
-  void listDatasetsUsingAdminPermissions() throws Exception {
+  void listDatasetsUsingAdminPermissions() {
     Map<String, StorageSystemInformation> workspaces = Map.of();
     var datasets = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER));
     when(datarepoService.getDatasets()).thenReturn(datasets);
@@ -176,6 +181,7 @@ class DatasetServiceTest {
     when(datasetDao.find(StorageSystem.TERRA_WORKSPACE, workspaces.keySet())).thenReturn(List.of());
     when(datasetDao.find(StorageSystem.TERRA_DATA_REPO, datasets.keySet()))
         .thenReturn(List.of(tdrDataset));
+    when(datasetDao.find(StorageSystem.EXTERNAL, Set.of())).thenReturn(List.of());
     when(datasetDao.listAllDatasets()).thenReturn(List.of(workspaceDataset, tdrDataset));
     ObjectNode tdrJson = (ObjectNode) datasetService.listDatasets().getResult().get(0);
     ObjectNode workspaceJson = (ObjectNode) datasetService.listDatasets().getResult().get(1);


### PR DESCRIPTION
Loading the dataset list from the catalog can take a long time. One of the reasons for this is because we were loading the data from underlying storage systems in sequence. This PR moves that to loading the underlying data in parallel, and then unifying once all the data has been fetched. It does this by using stream parallelism. The added complexity in this PR is a result of Spring Request Context not being copied down to child threads. In this case, because we know this request doesn't close until after all the child threads have finished execution, we want to copy down that request context.

Ticket: https://broadworkbench.atlassian.net/browse/DC-420

Timing:
Before:
curl -X 'GET' 'localhost:8080/api/v1/datasets' -H 'accept: application/json'   0.01s user 0.01s system 1% cpu 1.451 total
After:
curl -X 'GET' 'http://localhost:8080/api/v1/datasets' -H  -H   0.01s user 0.01s system 3% cpu 0.445 total