### PR TITLE
DC-594: list dataset performance improvement: reduce DB calls

### DIFF
--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -133,7 +133,7 @@ public class DatasetService {
                       Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().keySet())));
     }
     var response = new DatasetsListResponse();
-    // This is used for the admin user, to provide dummy role for datasets an admin
+    // This is used for the admin user, to provide a dummy role for datasets that an admin
     // doesn't have access to in the underlying storage system.
     var defaultInformation = new StorageSystemInformation(DatasetAccessLevel.READER);
     response.setResult(

--- a/service/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/service/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -122,7 +122,6 @@ public class DatasetService {
             .collect(
                 Collectors.toMap(Function.identity(), system -> getService(system).getDatasets()));
 
-
     List<Dataset> datasets;
     if (samService.hasGlobalAction(SamAction.READ_ANY_METADATA)) {
       datasets = datasetDao.listAllDatasets();

--- a/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
+++ b/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
@@ -119,7 +119,7 @@ public class DatasetDao {
   // JdbcTemplate to perform all text substitutions.
   @SuppressWarnings("java:S2077")
   public List<Dataset> find(Map<StorageSystem, Collection<String>> systemsAndIds) {
-    String query = "(storage_system = ? AND storage_source_id IN %s)";
+    String query = "(storage_system = ? AND storage_source_id IN (%s))";
     List<Object> args = new ArrayList<>();
     String whereClause =
         systemsAndIds.entrySet().stream()
@@ -128,11 +128,11 @@ public class DatasetDao {
                 entry -> {
                   args.add(String.valueOf(entry.getKey()));
                   args.addAll(entry.getValue());
-                  String inQuery =
+                  return String.format(
+                      query,
                       Stream.generate(() -> "?")
                           .limit(entry.getValue().size())
-                          .collect(Collectors.joining(", ", "(", ")"));
-                  return query.formatted(inQuery);
+                          .collect(Collectors.joining(", ")));
                 })
             .collect(Collectors.joining(" OR "));
 

--- a/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
+++ b/service/src/main/java/bio/terra/catalog/service/dataset/DatasetDao.java
@@ -115,6 +115,9 @@ public class DatasetDao {
   }
 
   @ReadTransaction
+  // This code is safe because it builds a template query string using ?s only. It relies on
+  // JdbcTemplate to perform all text substitutions.
+  @SuppressWarnings("java:S2077")
   public List<Dataset> find(Map<StorageSystem, Collection<String>> systemsAndIds) {
     String query = "(storage_system = ? AND storage_source_id IN %s)";
     List<Object> args = new ArrayList<>();

--- a/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -141,9 +142,9 @@ class DatasetServiceTest {
     String phsId = "1234";
     var idToRole = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER, phsId));
     when(datarepoService.getDatasets()).thenReturn(idToRole);
-    // FIXME: need to mock better, something like
-    // find(argThat(hasEntry(StorageSystem.TERRA_DATA_REPO, idToRole.keySet()))
-    when(datasetDao.find(any())).thenReturn(List.of(tdrDataset));
+    when(datasetDao.find(
+            argThat(map -> map.get(StorageSystem.TERRA_DATA_REPO).equals(idToRole.keySet()))))
+        .thenReturn(List.of(tdrDataset));
     ObjectNode tdrJson = (ObjectNode) datasetService.listDatasets().getResult().get(0);
     assertThat(tdrJson.get("phsId").asText(), is(phsId));
     assertTrue(tdrJson.has("requestAccessURL"));
@@ -155,8 +156,8 @@ class DatasetServiceTest {
     var idToRole = Map.of(SOURCE_ID, new StorageSystemInformation(DatasetAccessLevel.OWNER, phsId));
     when(datarepoService.getDatasets()).thenReturn(idToRole);
     var url = "url";
-    // FIXME: need to mock better
-    when(datasetDao.find(any()))
+    when(datasetDao.find(
+            argThat(map -> map.get(StorageSystem.TERRA_DATA_REPO).equals(idToRole.keySet()))))
         .thenReturn(
             List.of(
                 tdrDataset.withMetadata(
@@ -176,7 +177,6 @@ class DatasetServiceTest {
     when(rawlsService.getDatasets()).thenReturn(workspaces);
     when(samService.hasGlobalAction(SamAction.READ_ANY_METADATA)).thenReturn(true);
     when(datasetDao.listAllDatasets()).thenReturn(List.of(workspaceDataset, tdrDataset));
-    // FIXME: This order-dependant test is fragile. Using a library like JSONAssert is one way to fit it.
     ObjectNode tdrJson = (ObjectNode) datasetService.listDatasets().getResult().get(1);
     ObjectNode workspaceJson = (ObjectNode) datasetService.listDatasets().getResult().get(0);
     assertThat(tdrJson.get("name").asText(), is("name"));

--- a/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -145,7 +145,6 @@ class DatasetServiceTest {
     when(datasetDao.find(
             argThat(map -> map.get(StorageSystem.TERRA_DATA_REPO).equals(idToRole.keySet()))))
         .thenReturn(List.of(tdrDataset));
-    when(datasetDao.find(StorageSystem.EXTERNAL, Set.of())).thenReturn(List.of());
 
     ObjectNode tdrJson = (ObjectNode) datasetService.listDatasets().getResult().get(0);
     assertThat(tdrJson.get("phsId").asText(), is(phsId));
@@ -166,7 +165,6 @@ class DatasetServiceTest {
                     """
             {"%s":"%s"}"""
                         .formatted(DatasetService.REQUEST_ACCESS_URL_PROPERTY_NAME, url))));
-    when(datasetDao.find(StorageSystem.EXTERNAL, Set.of())).thenReturn(List.of());
 
     ObjectNode tdrJson = (ObjectNode) datasetService.listDatasets().getResult().get(0);
     assertThat(tdrJson.get("phsId").asText(), is(phsId));

--- a/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
@@ -120,7 +120,7 @@ class DatasetDaoTest {
   }
 
   @Test
-  void testFindNoIds() {
+  void findNoIds() {
     assertThat(datasetDao.find(Map.of(StorageSystem.EXTERNAL, List.of())), empty());
   }
 }

--- a/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
+++ b/service/src/test/java/bio/terra/catalog/service/dataset/DatasetDaoTest.java
@@ -12,7 +12,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.catalog.common.StorageSystem;
 import bio.terra.catalog.service.dataset.exception.DatasetNotFoundException;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -100,21 +102,25 @@ class DatasetDaoTest {
   }
 
   @Test
-  void testFind() {
-    String storageSourceId = UUID.randomUUID().toString();
-    Dataset d1 = upsertDataset(storageSourceId, StorageSystem.TERRA_DATA_REPO);
+  void find() {
+    Dataset d1 = upsertDataset(UUID.randomUUID().toString(), StorageSystem.TERRA_DATA_REPO);
+    Dataset d2 = upsertDataset(UUID.randomUUID().toString(), StorageSystem.TERRA_DATA_REPO);
     // Create a TDR dataset that we don't request in the query below.
-    String storageSourceId2 = UUID.randomUUID().toString();
-    upsertDataset(storageSourceId2, StorageSystem.TERRA_DATA_REPO);
-    Dataset d3 = upsertDataset(storageSourceId, StorageSystem.EXTERNAL);
-    var datasets =
-        datasetDao.find(
-            StorageSystem.TERRA_DATA_REPO, List.of(d1.storageSourceId(), d3.storageSourceId()));
-    assertThat(datasets, contains(d1));
+    upsertDataset(UUID.randomUUID().toString(), StorageSystem.TERRA_DATA_REPO);
+    Dataset d3 = upsertDataset(UUID.randomUUID().toString(), StorageSystem.EXTERNAL);
+
+    Map<StorageSystem, Collection<String>> systemsAndIds =
+        Map.of(
+            StorageSystem.TERRA_DATA_REPO,
+            List.of(d1.storageSourceId(), d2.storageSourceId()),
+            StorageSystem.EXTERNAL,
+            List.of(d3.storageSourceId()));
+    var datasets = datasetDao.find(systemsAndIds);
+    assertThat(datasets, contains(d1, d2, d3));
   }
 
   @Test
   void testFindNoIds() {
-    assertThat(datasetDao.find(StorageSystem.EXTERNAL, List.of()), empty());
+    assertThat(datasetDao.find(Map.of(StorageSystem.EXTERNAL, List.of())), empty());
   }
 }


### PR DESCRIPTION
Split out database operation from code that collects datasets from systems, to avoid doing multiple database calls.

The query builder code isn't great, but it is careful to not do any text substitution. It only builds a string that contains `?` placeholders that JdbcTemplate uses to do the actual parameter substitution.

Note that this PR conflicts with with https://github.com/DataBiosphere/terra-data-catalog/pull/154 and will be merged after that PR is merged.