### PR TITLE
DC-605: fix permission issue with admin user and dataset GET operation

### DIFF
--- a/common/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/common/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -39,7 +39,7 @@ public class DatasetService {
    * This is used for the admin user to provide default information for datasets that an admin
    * doesn't have access to in the underlying storage system.
    */
-  private static final StorageSystemInformation ADMIN_INFORMATION =
+  private static final StorageSystemInformation DEFAULT_INFORMATION =
       new StorageSystemInformation(DatasetAccessLevel.READER);
 
   private final DatarepoService datarepoService;
@@ -150,7 +150,7 @@ public class DatasetService {
                         dataset,
                         systemsAndInfo
                             .getOrDefault(dataset.storageSystem(), Map.of())
-                            .getOrDefault(dataset.storageSourceId(), ADMIN_INFORMATION)))
+                            .getOrDefault(dataset.storageSourceId(), DEFAULT_INFORMATION)))
             .map(DatasetResponse::convertToObject)
             .toList());
     return response;
@@ -180,7 +180,7 @@ public class DatasetService {
     try {
       information = getService(dataset.storageSystem()).getDataset(dataset.storageSourceId());
     } catch (DatarepoException e) {
-      information = ADMIN_INFORMATION;
+      information = DEFAULT_INFORMATION;
     }
     return new DatasetResponse(dataset, information).convertToObject().toString();
   }

--- a/common/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/common/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -35,8 +35,8 @@ public class DatasetService {
   public static final String PHS_ID_PROPERTY_NAME = "phsId";
 
   /**
-   *  This is used for the admin user to provide default information for datasets that an admin
-   *  doesn't have access to in the underlying storage system.
+   * This is used for the admin user to provide default information for datasets that an admin
+   * doesn't have access to in the underlying storage system.
    */
   private static final StorageSystemInformation ADMIN_INFORMATION =
       new StorageSystemInformation(DatasetAccessLevel.READER);

--- a/common/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/common/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -4,6 +4,7 @@ import bio.terra.catalog.common.RequestContextCopier;
 import bio.terra.catalog.common.StorageSystem;
 import bio.terra.catalog.common.StorageSystemInformation;
 import bio.terra.catalog.common.StorageSystemService;
+import bio.terra.catalog.datarepo.DatarepoException;
 import bio.terra.catalog.datarepo.DatarepoService;
 import bio.terra.catalog.iam.SamAction;
 import bio.terra.catalog.iam.SamService;
@@ -178,7 +179,7 @@ public class DatasetService {
     StorageSystemInformation information;
     try {
       information = getService(dataset.storageSystem()).getDataset(dataset.storageSourceId());
-    } catch (ForbiddenException e) {
+    } catch (DatarepoException e) {
       information = ADMIN_INFORMATION;
     }
     return new DatasetResponse(dataset, information).convertToObject().toString();

--- a/common/src/main/java/bio/terra/catalog/service/DatasetService.java
+++ b/common/src/main/java/bio/terra/catalog/service/DatasetService.java
@@ -33,6 +33,14 @@ import org.springframework.stereotype.Service;
 public class DatasetService {
   public static final String REQUEST_ACCESS_URL_PROPERTY_NAME = "requestAccessURL";
   public static final String PHS_ID_PROPERTY_NAME = "phsId";
+
+  /**
+   *  This is used for the admin user to provide default information for datasets that an admin
+   *  doesn't have access to in the underlying storage system.
+   */
+  private static final StorageSystemInformation ADMIN_INFORMATION =
+      new StorageSystemInformation(DatasetAccessLevel.READER);
+
   private final DatarepoService datarepoService;
   private final RawlsService rawlsService;
   private final SamService samService;
@@ -133,9 +141,6 @@ public class DatasetService {
                       Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().keySet())));
     }
     var response = new DatasetsListResponse();
-    // This is used for the admin user, to provide a dummy role for datasets that an admin
-    // doesn't have access to in the underlying storage system.
-    var defaultInformation = new StorageSystemInformation(DatasetAccessLevel.READER);
     response.setResult(
         datasets.stream()
             .map(
@@ -144,7 +149,7 @@ public class DatasetService {
                         dataset,
                         systemsAndInfo
                             .getOrDefault(dataset.storageSystem(), Map.of())
-                            .getOrDefault(dataset.storageSourceId(), defaultInformation)))
+                            .getOrDefault(dataset.storageSourceId(), ADMIN_INFORMATION)))
             .map(DatasetResponse::convertToObject)
             .toList());
     return response;
@@ -170,10 +175,13 @@ public class DatasetService {
   public String getMetadata(DatasetId datasetId) {
     var dataset = datasetDao.retrieve(datasetId);
     ensureActionPermission(dataset, SamAction.READ_ANY_METADATA);
-    return new DatasetResponse(
-            dataset, getService(dataset.storageSystem()).getDataset(dataset.storageSourceId()))
-        .convertToObject()
-        .toString();
+    StorageSystemInformation information;
+    try {
+      information = getService(dataset.storageSystem()).getDataset(dataset.storageSourceId());
+    } catch (ForbiddenException e) {
+      information = ADMIN_INFORMATION;
+    }
+    return new DatasetResponse(dataset, information).convertToObject().toString();
   }
 
   public void updateMetadata(DatasetId datasetId, String metadata) {

--- a/common/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/common/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -88,7 +88,8 @@ class DatasetServiceTest {
 
   private static String metadataWithIdAndAccess(DatasetId id, DatasetAccessLevel accessLevel) {
     return """
-    {"name":"name","accessLevel":"%s","id":"%s"}""".formatted(accessLevel, id.uuid());
+    {"name":"name","accessLevel":"%s","id":"%s"}"""
+        .formatted(accessLevel, id.uuid());
   }
 
   @BeforeEach

--- a/common/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
+++ b/common/src/test/java/bio/terra/catalog/service/DatasetServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import bio.terra.catalog.common.StorageSystem;
 import bio.terra.catalog.common.StorageSystemInformation;
 import bio.terra.catalog.config.BeanConfig;
+import bio.terra.catalog.datarepo.DatarepoException;
 import bio.terra.catalog.datarepo.DatarepoService;
 import bio.terra.catalog.iam.SamAction;
 import bio.terra.catalog.iam.SamService;
@@ -27,6 +28,7 @@ import bio.terra.catalog.service.dataset.DatasetDao;
 import bio.terra.catalog.service.dataset.DatasetId;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.ForbiddenException;
+import bio.terra.datarepo.client.ApiException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -154,7 +156,8 @@ class DatasetServiceTest {
   void getMetadataAdminUserNoAccess() throws Exception {
     mockDataset();
     when(samService.hasGlobalAction(SamAction.READ_ANY_METADATA)).thenReturn(true);
-    when(externalSystemService.getDataset(SOURCE_ID)).thenThrow(new ForbiddenException(""));
+    when(externalSystemService.getDataset(SOURCE_ID))
+        .thenThrow(new DatarepoException(new ApiException()));
     JSONAssert.assertEquals(
         metadataWithIdAndAccess(dataset.id(), DatasetAccessLevel.READER),
         datasetService.getMetadata(dataset.id()),

--- a/integration/src/main/java/scripts/testscripts/DatasetPermissionOperations.java
+++ b/integration/src/main/java/scripts/testscripts/DatasetPermissionOperations.java
@@ -179,6 +179,9 @@ public class DatasetPermissionOperations extends TestScript {
     CreateDatasetRequest request = datasetRequest(userTestSnapshotId.toString(), StorageSystem.TDR);
     var datasetId = adminCreateDataset(request);
 
+    // Verify admin can get the dataset metadata even when they don't have access to the snapshot.
+    adminDatasetsApi.getDataset(datasetId);
+
     // But admin cannot access the underlying preview data
     assertThrows(Exception.class, () -> adminDatasetsApi.listDatasetPreviewTables(datasetId));
     assertTrue(


### PR DESCRIPTION
With this change, an admin user can again `GET` any dataset in the catalog, even if they don't have access to the storage object in the underlying storage system.