### PR TITLE
DC-570, DC-622: Add example JSON for request body using openapi's `externalValue` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,13 @@ generate a report, run using `--info`:
 ```shell
 ./gradlew sonarqube --info
 ```
+
+## Dataset entry schema
+
+Datasets in the catalog (also known as catalog entries) have a JSON schema that they must conform to.
+The current schema for dataset entries is [schema.json](common/src/main/resources/schema/development/schema.json),
+and an example entry that conforms to this schema is [example.json](common/src/main/resources/schema/development/example.json).
+This schema is based on the [TerraDCAT_AP model](https://github.com/DataBiosphere/terra-interoperability-model/blob/master/releases/1.x/terra-core/TerraDCAT-AP.ttl)
+from the [Terra Interoperability Model](https://github.com/DataBiosphere/terra-interoperability-model).
+
+The example entry was generated from the JSON schema using the online tool [JSON Schema Faker](https://json-schema-faker.js.org).

--- a/common/src/main/resources/schema/development/example.json
+++ b/common/src/main/resources/schema/development/example.json
@@ -1,0 +1,1 @@
+{"example": "json"}

--- a/common/src/main/resources/schema/development/example.json
+++ b/common/src/main/resources/schema/development/example.json
@@ -1,1 +1,197 @@
-{"example": "json"}
+{
+  "dct:title": "eiusmod",
+  "dct:description": "ex",
+  "dct:creator": "ea",
+  "dct:issued": "1972-06-02T08:42:53.0Z",
+  "TerraDCAT_ap:hasDataCollection": [
+    {
+      "dct:modified": "1957-10-06T02:22:04.0Z",
+      "dct:publisher": "qui enim dolor Excepteur Ut",
+      "dct:title": "nisi ut laboris nulla",
+      "dct:creator": "cillum voluptate anim elit dolor",
+      "dct:description": "elit reprehenderit do",
+      "dct:identifier": "eiusmod anim nulla proident Duis",
+      "dct:issued": "1979-10-26T20:48:46.0Z"
+    },
+    {
+      "dct:issued": "1988-04-08T06:33:06.0Z",
+      "dct:creator": "sed do ex mollit minim",
+      "dct:title": "veniam occaecat culpa tempor minim",
+      "dct:modified": "1943-12-25T06:59:04.0Z"
+    },
+    {
+      "dct:title": "sed nisi veniam",
+      "dct:description": "labore cillum dolor sunt et",
+      "dct:modified": "1948-03-07T11:45:21.0Z",
+      "dct:publisher": "irure",
+      "dct:issued": "1982-06-27T15:10:57.0Z",
+      "dct:identifier": "ut Ut in Duis dolore",
+      "dct:creator": "consectetur sit laboris"
+    }
+  ],
+  "dcat:accessURL": "fugiat reprehenderit eu",
+  "storage": [
+    {
+      "cloudPlatform": "gcp",
+      "qui_6a8": "magna est ipsum nostrud non",
+      "exe8_": "ullamco",
+      "dolor4bb": -93389314,
+      "mollite": 18273837.309168965,
+      "ut__": "et tempor consequat non mollit",
+      "inf6": false
+    },
+    {
+      "cloudResource": "application_deployment",
+      "region": "centralusstage",
+      "cloudPlatform": "azure"
+    },
+    {
+      "officia90": "mollit nisi fugiat",
+      "sint_886": 39193575,
+      "in708": true
+    },
+    {
+      "region": "ukwest",
+      "cloudPlatform": "azure",
+      "cloudResource": "application_deployment",
+      "dolore_25": 45212730,
+      "in_8": 21809450.76485683
+    },
+    {
+      "cloudPlatform": "azure",
+      "region": "europe",
+      "cloudResource": "synapse_workspace",
+      "proidentb0": -1669074.48199068,
+      "esseb3": true
+    }
+  ],
+  "counts": {
+    "files": -48022071,
+    "donors": 71794624,
+    "incididunt_6b": -85982146,
+    "euf6": "ut ipsum commodo magna ut",
+    "cupidatat_93": "mollit",
+    "ad0": -8528955
+  },
+  "contributors": [
+    {
+      "additionalInformation": {
+        "anim5": true,
+        "amet4b": true
+      },
+      "email": "aute fugiat amet ullamco laborum",
+      "name": "fugiat id voluptate incididunt minim"
+    },
+    {
+      "do9": 53113890.57188231,
+      "officia5df": -78638841.55110909,
+      "laboris_3d6": 71622431,
+      "Duis97": "cillum et Lorem ex"
+    },
+    {
+      "additionalInformation": {
+        "non16f": -76396469,
+        "nostrud6e": "eiusmod in in"
+      },
+      "name": "tempor adipisicing ut sint anim",
+      "email": "nostrud"
+    },
+    {
+      "name": "magna",
+      "additionalInformation": {
+        "labore_24": false,
+        "ut_2": "in cillum proident",
+        "consectetur_428": false
+      },
+      "email": "nisi"
+    },
+    {
+      "additionalInformation": {
+        "ut8d5": -85210982.3141007,
+        "voluptate8": "nulla in culpa qui",
+        "sunt_50f": -52050872.30007373
+      },
+      "name": "tempor irure aliquip aute consequat",
+      "email": "nostrud",
+      "veniam__2": "in proident ipsum ex ut"
+    }
+  ],
+  "TerraCore:id": "in enim velit eu tempor",
+  "TerraDCAT_ap:hasGenomicDataType": [
+    "sunt tempor cupidatat",
+    "quis in"
+  ],
+  "dct:modified": "1980-06-13T10:38:26.0Z",
+  "samples": {
+    "disease": [
+      "cupidatat dolor officia consectetur Lorem"
+    ],
+    "species": [
+      "Excepteur occaecat culpa sed",
+      "aliqua Lorem",
+      "enim labore",
+      "ullamco",
+      "enim velit qui"
+    ],
+    "adipisicing_5": 78399601,
+    "consectetur_ef": 54308056,
+    "Ut5": -26621229.330413684,
+    "proident87": -33749174.293875515,
+    "id_22": 68329722.31689748
+  },
+  "prov:wasGeneratedBy": [
+    {
+      "TerraCore:hasAssayCategory": [
+        "dolore laborum sunt",
+        "non",
+        "laboris",
+        "laboris",
+        "et quis ipsum ex cillum"
+      ],
+      "TerraCore:hasDataModality": [
+        "anim commodo eu",
+        "exercitation id",
+        "adipisicing Excepteur nisi",
+        "quis dolor laborum",
+        "sint magna Excepteur velit"
+      ]
+    }
+  ],
+  "TerraDCAT_ap:hasPhenotypeDataType": [
+    "reprehenderit",
+    "Ut qui id",
+    "enim"
+  ],
+  "TerraDCAT_ap:hasCustodian": [
+    "pariatur magna reprehenderit",
+    "Ut aute sunt",
+    "proident",
+    "fugiat veniam Ut sunt",
+    "esse labore do ut velit"
+  ],
+  "TerraCoreValueSets:SampleType": [
+    "aliqua minim ad quis in",
+    "velit reprehenderit dolor sed",
+    "Lorem dolore",
+    "sed Duis officia irure",
+    "voluptate consectetur pariatur laboris deserunt"
+  ],
+  "requestAccessURL": "ut nulla incididunt",
+  "TerraDCAT_ap:hasPublication": [
+    {
+      "dcat:accessURL": "eu mollit",
+      "dct:title": "pariatur est"
+    },
+    {
+      "dct:title": "dolore laboris ea in",
+      "dcat:accessURL": "aliqua ut dolor fugiat esse",
+      "quis_2_": 46259580,
+      "ex_6": -64460245.0798847
+    }
+  ],
+  "TerraDCAT_ap:hasOwner": "et dolore in minim",
+  "TerraDCAT_ap:hasOriginalPublication": {
+    "dcat:accessURL": "cupidatat",
+    "dct:title": "nisi"
+  }
+}

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -106,6 +106,10 @@ paths:
           application/json:
             schema:
               type: string
+            examples:
+              dataset:
+                summary: An example dataset
+                externalValue: 'example.json'
         required: true
       responses:
         204:

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -58,6 +58,8 @@ paths:
       tags: [ datasets ]
       description: |
         ⚠️ Do not add sensitive data. All catalog entries are publicly accessible to all Terra users. ⚠️
+
+        Catalog entries must conform to [this schema](schema.json)
       operationId: upsertDataset
       requestBody:
         content:
@@ -97,6 +99,8 @@ paths:
       tags: [ datasets ]
       description: |
         ⚠️ Do not add sensitive data. All catalog entries are publicly accessible to all Terra users. ⚠️
+
+        Catalog entries must conform to [this schema](schema.json)
       operationId: updateDataset
       parameters:
         - $ref: '#/components/parameters/Id'
@@ -108,7 +112,7 @@ paths:
               type: string
             examples:
               dataset:
-                summary: An example dataset
+                summary: Example dataset
                 externalValue: 'example.json'
         required: true
       responses:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -38,7 +38,7 @@ spring:
           maxAge: 0
           mustRevalidate: true
         useLastModified: false
-      staticLocations: classpath:/api/
+      staticLocations: classpath:/api/,classpath:/schema/development/
 
 catalog:
   ingress:

--- a/service/src/main/resources/templates/index.html
+++ b/service/src/main/resources/templates/index.html
@@ -76,15 +76,6 @@
 <script src="/webjars/swagger-ui-dist/swagger-ui-standalone-preset.js"> </script>
 <script th:inline="javascript">
 
-    // Removes the online validation since some code gen bugs cause us to have some specs that cause the validator to squawk
-  const clearValidator = function(system) {
-    return {
-      components: {
-        onlineValidatorBadge: function() { return null; },
-      }
-    };
-  }
-
     // Examples cache
     const examplesCache = {};
 
@@ -141,7 +132,7 @@
         clearValidator,
         LoadExternalValuePlugin
       ],
-      layout: 'StandaloneLayout',
+      displayOperationId: true,
       displayRequestDuration: true,
       tryItOutEnabled: true,
       defaultModelsExpandDepth: 0,

--- a/service/src/main/resources/templates/index.html
+++ b/service/src/main/resources/templates/index.html
@@ -76,31 +76,6 @@
 <script src="/webjars/swagger-ui-dist/swagger-ui-standalone-preset.js"> </script>
 <script th:inline="javascript">
 
-   // Adds support for pinning the auth bar when the user scrolls down far enough to hide the bar
-    const pinLoginPlugin = function(system) {
-      return {
-        afterLoad: function(system) {
-          var offsetY;
-          var authBar;
-          document.addEventListener('scroll', function() {
-            if (offsetY === undefined) {
-              // Note: the auth bar is not a React component, so we can't use the standard plugin approach to modify
-              var authBars = document.getElementsByClassName('scheme-container');
-              if (authBars.length > 0) {
-                authBar = authBars[0];
-                offsetY = authBar.offsetTop;
-              }
-            }
-            if (window.scrollY > offsetY) {
-              authBar.classList.add('pinned');
-            } else {
-              authBar.classList.remove('pinned');
-            }
-          });
-        }
-      }
-    }
-
     // Removes the online validation since some code gen bugs cause us to have some specs that cause the validator to squawk
   const clearValidator = function(system) {
     return {
@@ -110,7 +85,65 @@
     };
   }
 
-  window.onload = function() {
+    // Examples map
+    const examples = {};
+
+    // Custom plugin for logic that happens before the response element is created
+    const LoadExternalValuePlugin = () => {
+      return {
+        wrapComponents: {
+          // wrapping https://github.com/swagger-api/swagger-ui/blob/master/src/core/components/parameters/parameters.jsx
+          parameters: (Original, { React, oas3Actions, oas3Selectors }) => (props) => {
+            const operation = props.operation
+            const pathMethod = props.pathMethod
+            // const contentType = oas3Selectors.requestContentType(...pathMethod)
+            const contentType = 'application/json'
+            // const activeExamplesKey = oas3Selectors.activeExamplesMember(
+            //   ...pathMethod,
+            //   "requestBody",
+            //   "requestBody", // RBs are currently not stored per-mediaType
+            // )
+            const activeExamplesKey = 'dataset'
+            // const externalValue = props.response.getIn(['content', contentType, 'examples', props.activeExamplesKey, 'externalValue'])
+            const externalValue = operation.getIn(['requestBody', 'content', contentType, 'examples', activeExamplesKey, 'externalValue'])
+            // Check if externalValue field exists
+            if (externalValue) {
+              // Check if examples map already contains externalValue key
+              if (examples[externalValue]) {
+                // Set example value directly from examples map
+                props.operation = operation.setIn(['requestBody', 'content', contentType, 'examples', activeExamplesKey, 'value'], examples[externalValue])
+              } else {
+                // Download external file
+                fetch(externalValue)
+                  .then(res => res.text())
+                  .then(data => {
+                    // Put downloaded file content into the examples map
+                    examples[externalValue] = data
+                    // Simulate select another example action
+                    oas3Actions.setActiveExamplesMember({
+                      "name": 'fake',
+                      "pathMethod": [props.path, props.method],
+                      "contextType": "responses",
+                      "contextName": props.code
+                    })
+                    // Reselect this example
+                    oas3Actions.setActiveExamplesMember({
+                      "name": props.activeExamplesKey,
+                      "pathMethod": [props.path, props.method],
+                      "contextType": "responses",
+                      "contextName": props.code
+                    })
+                  })
+                  .catch(e => console.error(e))
+              }
+            }
+            return React.createElement(Original, props)
+          }
+        }
+      }
+    }
+
+    window.onload = function() {
     // Begin Swagger UI call region
     const ui = SwaggerUIBundle({
       url: 'openapi.yml',
@@ -122,12 +155,13 @@
       ],
       plugins: [
         SwaggerUIBundle.plugins.DownloadUrl,
-        pinLoginPlugin,
-        clearValidator
+        clearValidator,
+        LoadExternalValuePlugin
       ],
       layout: 'StandaloneLayout',
-      displayOperationId: true,
-      docExpansion: 'none',
+      displayRequestDuration: true,
+      tryItOutEnabled: true,
+      defaultModelsExpandDepth: 0,
       oauth2RedirectUrl: window.location.protocol + '//' + window.location.host + '/webjars/swagger-ui-dist/oauth2-redirect.html'
     })
     // End Swagger UI call region

--- a/service/src/main/resources/templates/index.html
+++ b/service/src/main/resources/templates/index.html
@@ -3,17 +3,16 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta
     name="description"
     content="Data Catalog SwaggerUI"
   />
   <title>Data Catalog SwaggerUI</title>
-  <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" >
+  <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css">
   <style>
-    html
-    {
+    html {
       box-sizing: border-box;
       overflow: -moz-scrollbars-vertical;
       overflow-y: scroll;
@@ -21,14 +20,12 @@
 
     *,
     *:before,
-    *:after
-    {
+    *:after {
       box-sizing: inherit;
     }
 
-    body
-    {
-      margin:0;
+    body {
+      margin: 0;
       background: #fafafa;
     }
 
@@ -52,6 +49,7 @@
     .swagger-ui details {
       margin-bottom: 20px;
     }
+
     .swagger-ui details summary {
       cursor: pointer;
     }
@@ -60,6 +58,7 @@
     .swagger-ui .scheme-container {
       position: relative;
     }
+
     .swagger-ui .scheme-container.pinned {
       position: fixed;
       top: 0;
@@ -72,52 +71,51 @@
 
 <body>
 <div id="swagger-ui"></div>
-<script src="/webjars/swagger-ui-dist/swagger-ui-bundle.js"> </script>
-<script src="/webjars/swagger-ui-dist/swagger-ui-standalone-preset.js"> </script>
+<script src="/webjars/swagger-ui-dist/swagger-ui-bundle.js"></script>
+<script src="/webjars/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
 <script th:inline="javascript">
 
-    // Examples cache
-    const examplesCache = {};
-
-    // Custom plugin for logic that happens before a parameters element is created, hardcoded
-    // to work with the dataset example in the PUT dataset operation.
-    const LoadExternalValuePlugin = () => {
-      return {
-        wrapComponents: {
-          // wrapping https://github.com/swagger-api/swagger-ui/blob/master/src/core/components/parameters/parameters.jsx
-          parameters: (Original, { React }) => (props) => {
-            // These hardcoded values should be replaced with code that determines the values
-            // using the user's current selection.
-            const contentType = 'application/json'
-            const activeExamplesKey = 'dataset'
-            const operation = props.operation
-            const externalValue = operation.getIn(['requestBody', 'content', contentType, 'examples', activeExamplesKey, 'externalValue'])
-
-            if (externalValue) {
-              if (examplesCache[externalValue]) {
-                // If the examples cache contains the externalValue key, set the example value
-                // directly from the cache.
-                props.operation = operation.setIn(['requestBody', 'content', contentType, 'examples', activeExamplesKey, 'value'], examplesCache[externalValue])
-              } else {
-                // Fetch the external file.
-                fetch(externalValue)
-                  .then(res => res.text())
-                  .then(data => {
-                    // Put fetched file content into the cache.
-                    examplesCache[externalValue] = JSON.parse(data)
-                    // At this point the cache contains the JSON data but the UI is not refreshed.
-                    // The code shold be able to use `oas3Actions` to refresh the UI.
-                  })
-                  .catch(e => console.error(e))
+  // Custom plugin for logic that happens before a parameters element is created, hardcoded
+  // to work with the dataset example in the PUT dataset operation.
+  const LoadExternalValuePlugin = () => {
+    return {
+      wrapComponents: {
+        // wrapping https://github.com/swagger-api/swagger-ui/blob/master/src/core/components/parameters/parameters.jsx
+        parameters: (Original, {React, oas3Actions}) => (props) => {
+          const {operation, pathMethod} = props
+          // These hardcoded values should be replaced with code that determines the values
+          // using the user's current selection.
+          const contentType = 'application/json'
+          const activeExamplesKey = 'dataset'
+          const externalValue = operation.getIn(['requestBody', 'content', contentType, 'examples', activeExamplesKey, 'externalValue'])
+          if (externalValue) {
+            const [example, setExample] = React.useState()
+            // Since openAPI3 (oas3) is responsible for rendering, use a side effect to force a re-render via the oas3 UI API
+            // Normally, in react the setState would be enough to get the rendered state we are after
+            React.useEffect(() => {
+              oas3Actions.setRequestBodyValue({pathMethod, value: example})
+            }, [example])
+            if (!example) {
+              fetch(externalValue)
+                .then(res => res.text())
+                .then(data => setExample(JSON.parse(data)))
+                .catch(e => console.error(e))
+            } else {
+              // Since we need to modify the props for everything to work correctly, let's be explicit about this
+              const updatedProps = {
+                ...props,
+                ...{operation: operation.setIn(['requestBody', 'content', contentType, 'examples', activeExamplesKey, 'value'], example)}
               }
+              return React.createElement(Original, updatedProps)
             }
-            return React.createElement(Original, props)
           }
+          return React.createElement(Original, props)
         }
       }
     }
+  }
 
-    window.onload = function() {
+  window.onload = function () {
     // Begin Swagger UI call region
     const ui = SwaggerUIBundle({
       url: 'openapi.yml',
@@ -129,7 +127,6 @@
       ],
       plugins: [
         SwaggerUIBundle.plugins.DownloadUrl,
-        clearValidator,
         LoadExternalValuePlugin
       ],
       displayOperationId: true,

--- a/service/src/main/resources/templates/index.html
+++ b/service/src/main/resources/templates/index.html
@@ -116,7 +116,7 @@
     }
   }
 
-  window.onload = function () {
+  window.onload = function() {
     // Begin Swagger UI call region
     const ui = SwaggerUIBundle({
       url: 'openapi.yml',

--- a/service/src/main/resources/templates/index.html
+++ b/service/src/main/resources/templates/index.html
@@ -85,54 +85,37 @@
     };
   }
 
-    // Examples map
-    const examples = {};
+    // Examples cache
+    const examplesCache = {};
 
-    // Custom plugin for logic that happens before the response element is created
+    // Custom plugin for logic that happens before a parameters element is created, hardcoded
+    // to work with the dataset example in the PUT dataset operation.
     const LoadExternalValuePlugin = () => {
       return {
         wrapComponents: {
           // wrapping https://github.com/swagger-api/swagger-ui/blob/master/src/core/components/parameters/parameters.jsx
-          parameters: (Original, { React, oas3Actions, oas3Selectors }) => (props) => {
-            const operation = props.operation
-            const pathMethod = props.pathMethod
-            // const contentType = oas3Selectors.requestContentType(...pathMethod)
+          parameters: (Original, { React }) => (props) => {
+            // These hardcoded values should be replaced with code that determines the values
+            // using the user's current selection.
             const contentType = 'application/json'
-            // const activeExamplesKey = oas3Selectors.activeExamplesMember(
-            //   ...pathMethod,
-            //   "requestBody",
-            //   "requestBody", // RBs are currently not stored per-mediaType
-            // )
             const activeExamplesKey = 'dataset'
-            // const externalValue = props.response.getIn(['content', contentType, 'examples', props.activeExamplesKey, 'externalValue'])
+            const operation = props.operation
             const externalValue = operation.getIn(['requestBody', 'content', contentType, 'examples', activeExamplesKey, 'externalValue'])
-            // Check if externalValue field exists
+
             if (externalValue) {
-              // Check if examples map already contains externalValue key
-              if (examples[externalValue]) {
-                // Set example value directly from examples map
-                props.operation = operation.setIn(['requestBody', 'content', contentType, 'examples', activeExamplesKey, 'value'], examples[externalValue])
+              if (examplesCache[externalValue]) {
+                // If the examples cache contains the externalValue key, set the example value
+                // directly from the cache.
+                props.operation = operation.setIn(['requestBody', 'content', contentType, 'examples', activeExamplesKey, 'value'], examplesCache[externalValue])
               } else {
-                // Download external file
+                // Fetch the external file.
                 fetch(externalValue)
                   .then(res => res.text())
                   .then(data => {
-                    // Put downloaded file content into the examples map
-                    examples[externalValue] = data
-                    // Simulate select another example action
-                    oas3Actions.setActiveExamplesMember({
-                      "name": 'fake',
-                      "pathMethod": [props.path, props.method],
-                      "contextType": "responses",
-                      "contextName": props.code
-                    })
-                    // Reselect this example
-                    oas3Actions.setActiveExamplesMember({
-                      "name": props.activeExamplesKey,
-                      "pathMethod": [props.path, props.method],
-                      "contextType": "responses",
-                      "contextName": props.code
-                    })
+                    // Put fetched file content into the cache.
+                    examplesCache[externalValue] = JSON.parse(data)
+                    // At this point the cache contains the JSON data but the UI is not refreshed.
+                    // The code shold be able to use `oas3Actions` to refresh the UI.
                   })
                   .catch(e => console.error(e))
               }

--- a/service/src/main/resources/templates/index.html
+++ b/service/src/main/resources/templates/index.html
@@ -3,16 +3,17 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta
     name="description"
     content="Data Catalog SwaggerUI"
   />
   <title>Data Catalog SwaggerUI</title>
-  <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css">
+  <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" >
   <style>
-    html {
+    html
+    {
       box-sizing: border-box;
       overflow: -moz-scrollbars-vertical;
       overflow-y: scroll;
@@ -20,12 +21,14 @@
 
     *,
     *:before,
-    *:after {
+    *:after
+    {
       box-sizing: inherit;
     }
 
-    body {
-      margin: 0;
+    body
+    {
+      margin:0;
       background: #fafafa;
     }
 
@@ -49,7 +52,6 @@
     .swagger-ui details {
       margin-bottom: 20px;
     }
-
     .swagger-ui details summary {
       cursor: pointer;
     }
@@ -58,7 +60,6 @@
     .swagger-ui .scheme-container {
       position: relative;
     }
-
     .swagger-ui .scheme-container.pinned {
       position: fixed;
       top: 0;
@@ -71,8 +72,8 @@
 
 <body>
 <div id="swagger-ui"></div>
-<script src="/webjars/swagger-ui-dist/swagger-ui-bundle.js"></script>
-<script src="/webjars/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
+<script src="/webjars/swagger-ui-dist/swagger-ui-bundle.js"> </script>
+<script src="/webjars/swagger-ui-dist/swagger-ui-standalone-preset.js"> </script>
 <script th:inline="javascript">
 
   // Custom plugin for logic that happens before a parameters element is created, hardcoded

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name = 'terra-data-catalog'
 include('admin-cli', 'service', 'client', 'rawls-client', 'common', 'integration', 'scripts')
 
-gradle.ext.releaseVersion = '0.123.0'
+gradle.ext.releaseVersion = '0.124.0'


### PR DESCRIPTION
This loads the swagger example content from an external file. It's hardcoded to work for the dataset example in for the dataset PUT operation. A future PR can improve on this work.

What works
- the code intercepts the use of `externalValue` in the PUT request body and loads an example JSON file using HTTP

What doesn't work
- can't get content type from page state
- can't get selected example from page state
- ~code to refresh page after load doesn't seem to work~
- ~example json is loaded as a string, not json object~
