### PR TITLE
DC-693: service startup error fix

### DIFF
--- a/common/src/main/java/bio/terra/catalog/service/CatalogStatusService.java
+++ b/common/src/main/java/bio/terra/catalog/service/CatalogStatusService.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class CatalogStatusService {
   private static final Logger logger = LoggerFactory.getLogger(CatalogStatusService.class);
+  /** Number of seconds to wait for a connection to the database. */
+  public static final int DB_CONNECTION_TIMEOUT = 1;
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -37,7 +39,7 @@ public class CatalogStatusService {
     try {
       logger.debug("Checking database connection valid");
       return new SystemStatusSystems()
-          .ok(jdbcTemplate.getJdbcTemplate().execute((Connection conn) -> conn.isValid(1)));
+          .ok(jdbcTemplate.getJdbcTemplate().execute((Connection conn) -> conn.isValid(DB_CONNECTION_TIMEOUT)));
     } catch (Exception ex) {
       String errorMsg = "Database status check failed";
       logger.error(errorMsg, ex);

--- a/common/src/main/java/bio/terra/catalog/service/CatalogStatusService.java
+++ b/common/src/main/java/bio/terra/catalog/service/CatalogStatusService.java
@@ -1,6 +1,5 @@
 package bio.terra.catalog.service;
 
-import bio.terra.catalog.config.StatusCheckConfiguration;
 import bio.terra.catalog.datarepo.DatarepoService;
 import bio.terra.catalog.iam.SamService;
 import bio.terra.catalog.model.SystemStatusSystems;
@@ -14,24 +13,23 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
-public class CatalogStatusService extends BaseStatusService {
+public class CatalogStatusService {
   private static final Logger logger = LoggerFactory.getLogger(CatalogStatusService.class);
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
   @Autowired
   public CatalogStatusService(
+      StatusCheckService statusCheckService,
       NamedParameterJdbcTemplate jdbcTemplate,
-      StatusCheckConfiguration configuration,
       SamService samService,
       DatarepoService datarepoService,
       RawlsService rawlsService) {
-    super(configuration);
     this.jdbcTemplate = jdbcTemplate;
-    registerStatusCheck("CloudSQL", this::databaseStatus);
-    registerStatusCheck("SAM", samService::status);
-    registerStatusCheck("Data Repo", datarepoService::status);
-    registerStatusCheck("Rawls", rawlsService::status);
+    statusCheckService.registerStatusCheck("CloudSQL", this::databaseStatus);
+    statusCheckService.registerStatusCheck("SAM", samService::status);
+    statusCheckService.registerStatusCheck("Data Repo", datarepoService::status);
+    statusCheckService.registerStatusCheck("Rawls", rawlsService::status);
   }
 
   @VisibleForTesting

--- a/common/src/main/java/bio/terra/catalog/service/CatalogStatusService.java
+++ b/common/src/main/java/bio/terra/catalog/service/CatalogStatusService.java
@@ -5,6 +5,7 @@ import bio.terra.catalog.datarepo.DatarepoService;
 import bio.terra.catalog.iam.SamService;
 import bio.terra.catalog.model.SystemStatusSystems;
 import bio.terra.catalog.rawls.RawlsService;
+import com.google.common.annotations.VisibleForTesting;
 import java.sql.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,11 +34,12 @@ public class CatalogStatusService extends BaseStatusService {
     registerStatusCheck("Rawls", rawlsService::status);
   }
 
-  private SystemStatusSystems databaseStatus() {
+  @VisibleForTesting
+  SystemStatusSystems databaseStatus() {
     try {
       logger.debug("Checking database connection valid");
       return new SystemStatusSystems()
-          .ok(jdbcTemplate.getJdbcTemplate().execute((Connection conn) -> conn.isValid(5000)));
+          .ok(jdbcTemplate.getJdbcTemplate().execute((Connection conn) -> conn.isValid(1)));
     } catch (Exception ex) {
       String errorMsg = "Database status check failed";
       logger.error(errorMsg, ex);

--- a/common/src/main/java/bio/terra/catalog/service/CatalogStatusService.java
+++ b/common/src/main/java/bio/terra/catalog/service/CatalogStatusService.java
@@ -39,7 +39,10 @@ public class CatalogStatusService {
     try {
       logger.debug("Checking database connection valid");
       return new SystemStatusSystems()
-          .ok(jdbcTemplate.getJdbcTemplate().execute((Connection conn) -> conn.isValid(DB_CONNECTION_TIMEOUT)));
+          .ok(
+              jdbcTemplate
+                  .getJdbcTemplate()
+                  .execute((Connection conn) -> conn.isValid(DB_CONNECTION_TIMEOUT)));
     } catch (Exception ex) {
       String errorMsg = "Database status check failed";
       logger.error(errorMsg, ex);

--- a/common/src/main/java/bio/terra/catalog/service/StatusCheckService.java
+++ b/common/src/main/java/bio/terra/catalog/service/StatusCheckService.java
@@ -5,8 +5,8 @@ import bio.terra.catalog.model.SystemStatus;
 import bio.terra.catalog.model.SystemStatusSystems;
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -16,9 +16,11 @@ import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
-public class BaseStatusService {
-  private static final Logger logger = LoggerFactory.getLogger(BaseStatusService.class);
+@Component
+public class StatusCheckService {
+  private static final Logger logger = LoggerFactory.getLogger(StatusCheckService.class);
   /** cached status */
   private final AtomicReference<SystemStatus> cachedStatus;
   /** configuration parameters */
@@ -30,9 +32,9 @@ public class BaseStatusService {
   /** last time cache was updated */
   private final AtomicReference<Instant> lastStatusUpdate;
 
-  public BaseStatusService(StatusCheckConfiguration configuration) {
+  public StatusCheckService(StatusCheckConfiguration configuration) {
     this.configuration = configuration;
-    statusCheckMap = new HashMap<>();
+    statusCheckMap = new ConcurrentHashMap<>();
     cachedStatus = new AtomicReference<>(new SystemStatus().ok(false));
     lastStatusUpdate = new AtomicReference<>(Instant.now());
     scheduler = Executors.newScheduledThreadPool(1);
@@ -50,7 +52,7 @@ public class BaseStatusService {
     }
   }
 
-  void registerStatusCheck(String name, Supplier<SystemStatusSystems> checkFn) {
+  public void registerStatusCheck(String name, Supplier<SystemStatusSystems> checkFn) {
     statusCheckMap.put(name, checkFn);
   }
 

--- a/common/src/test/java/bio/terra/catalog/service/CatalogStatusServiceTest.java
+++ b/common/src/test/java/bio/terra/catalog/service/CatalogStatusServiceTest.java
@@ -1,0 +1,60 @@
+package bio.terra.catalog.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import bio.terra.catalog.datarepo.DatarepoService;
+import bio.terra.catalog.iam.SamService;
+import bio.terra.catalog.rawls.RawlsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class CatalogStatusServiceTest {
+  @Mock private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+  @Mock private JdbcTemplate jdbcTemplate;
+
+  private CatalogStatusService catalogStatusService;
+
+  @BeforeEach
+  public void beforeEach() {
+    catalogStatusService =
+        new CatalogStatusService(
+            namedParameterJdbcTemplate,
+            null,
+            mock(SamService.class),
+            mock(DatarepoService.class),
+            mock(RawlsService.class));
+    when(namedParameterJdbcTemplate.getJdbcTemplate()).thenReturn(jdbcTemplate);
+  }
+
+  @Test
+  void databaseStatus() {
+    when(jdbcTemplate.execute(ArgumentMatchers.<ConnectionCallback<Boolean>>any()))
+        .thenReturn(true);
+    assertTrue(catalogStatusService.databaseStatus().isOk());
+  }
+
+  @Test
+  void databaseStatusError() {
+    var message = "expected error message";
+    when(jdbcTemplate.execute(ArgumentMatchers.<ConnectionCallback<Boolean>>any()))
+        .thenThrow(new DataAccessException(message) {});
+    var status = catalogStatusService.databaseStatus();
+    assertFalse(status.isOk());
+    assertThat(status.getMessages(), hasItem(containsString(message)));
+  }
+}

--- a/common/src/test/java/bio/terra/catalog/service/CatalogStatusServiceTest.java
+++ b/common/src/test/java/bio/terra/catalog/service/CatalogStatusServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 @ExtendWith(MockitoExtension.class)
 class CatalogStatusServiceTest {
+  @Mock private StatusCheckService statusCheckService;
   @Mock private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
   @Mock private JdbcTemplate jdbcTemplate;
 
@@ -33,8 +34,8 @@ class CatalogStatusServiceTest {
   public void beforeEach() {
     catalogStatusService =
         new CatalogStatusService(
+            statusCheckService,
             namedParameterJdbcTemplate,
-            null,
             mock(SamService.class),
             mock(DatarepoService.class),
             mock(RawlsService.class));

--- a/common/src/test/java/bio/terra/catalog/service/StatusCheckServiceTest.java
+++ b/common/src/test/java/bio/terra/catalog/service/StatusCheckServiceTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import bio.terra.catalog.config.StatusCheckConfiguration;
 import bio.terra.catalog.model.SystemStatus;
@@ -12,12 +13,12 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
-class BaseStatusServiceTest {
+class StatusCheckServiceTest {
 
   @Test
   void getCurrentStatus() {
     var config = new StatusCheckConfiguration(true, 0, 0, 10);
-    BaseStatusService service = new BaseStatusService(config);
+    StatusCheckService service = new StatusCheckService(config);
     var status = new SystemStatusSystems().ok(true);
     service.registerStatusCheck("test", () -> status);
     assertThat(service.getCurrentStatus(), is(new SystemStatus().ok(false)));
@@ -30,8 +31,7 @@ class BaseStatusServiceTest {
   @Test
   void getCurrentStatusException() {
     var config = new StatusCheckConfiguration(true, 0, 0, 10);
-    BaseStatusService service = new BaseStatusService(config);
-    var status = new SystemStatusSystems().ok(true);
+    StatusCheckService service = new StatusCheckService(config);
     service.registerStatusCheck(
         "test",
         () -> {
@@ -48,8 +48,9 @@ class BaseStatusServiceTest {
   @Test
   void startStatusChecking() throws InterruptedException {
     var config = new StatusCheckConfiguration(true, 1, 0, 10);
-    BaseStatusService service = new BaseStatusService(config);
+    StatusCheckService service = new StatusCheckService(config);
     var status = mock(Status.class);
+    when(status.get()).thenReturn(new SystemStatusSystems().ok(true));
     service.registerStatusCheck("", status);
     service.startStatusChecking();
     Thread.sleep(500);
@@ -59,7 +60,7 @@ class BaseStatusServiceTest {
   @Test
   void getNonEnabledStatus() {
     var config = new StatusCheckConfiguration(false, 0, 0, 10);
-    BaseStatusService service = new BaseStatusService(config);
+    StatusCheckService service = new StatusCheckService(config);
     assertThat(service.getCurrentStatus(), is(new SystemStatus().ok(true)));
   }
 }

--- a/service/src/main/java/bio/terra/catalog/controller/PublicApiController.java
+++ b/service/src/main/java/bio/terra/catalog/controller/PublicApiController.java
@@ -4,9 +4,10 @@ import bio.terra.catalog.api.PublicApi;
 import bio.terra.catalog.config.VersionConfiguration;
 import bio.terra.catalog.model.SystemStatus;
 import bio.terra.catalog.model.VersionProperties;
-import bio.terra.catalog.service.CatalogStatusService;
+import bio.terra.catalog.service.StatusCheckService;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,21 +17,21 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class PublicApiController implements PublicApi {
-  private final CatalogStatusService statusService;
+  private final StatusCheckService statusService;
   private final VersionConfiguration versionConfiguration;
 
   private final String swaggerClientId;
 
   @Autowired
   public PublicApiController(
-      CatalogStatusService statusService, VersionConfiguration versionConfiguration) {
+      StatusCheckService statusService, VersionConfiguration versionConfiguration) {
     this.statusService = statusService;
     this.versionConfiguration = versionConfiguration;
 
     String clientId = "";
 
     try (var stream = getClass().getResourceAsStream("/rendered/swagger-client-id")) {
-      clientId = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+      clientId = new String(Objects.requireNonNull(stream).readAllBytes(), StandardCharsets.UTF_8);
     } catch (IOException | NullPointerException e) {
       log.error(
           "It doesn't look like configs have been rendered! Unable to parse swagger client id.", e);

--- a/service/src/test/java/bio/terra/catalog/controller/PublicApiControllerTest.java
+++ b/service/src/test/java/bio/terra/catalog/controller/PublicApiControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.catalog.config.VersionConfiguration;
 import bio.terra.catalog.model.SystemStatus;
-import bio.terra.catalog.service.CatalogStatusService;
+import bio.terra.catalog.service.StatusCheckService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -23,7 +23,7 @@ class PublicApiControllerTest {
 
   @Autowired private MockMvc mockMvc;
 
-  @MockBean private CatalogStatusService statusService;
+  @MockBean private StatusCheckService statusService;
 
   @MockBean private VersionConfiguration versionConfiguration;
 
@@ -31,14 +31,14 @@ class PublicApiControllerTest {
   void testStatus() throws Exception {
     SystemStatus systemStatus = new SystemStatus().ok(true);
     when(statusService.getCurrentStatus()).thenReturn(systemStatus);
-    this.mockMvc.perform(get("/status")).andExpect(status().isOk());
+    mockMvc.perform(get("/status")).andExpect(status().isOk());
   }
 
   @Test
   void testStatusCheckFails() throws Exception {
     SystemStatus systemStatus = new SystemStatus().ok(false);
     when(statusService.getCurrentStatus()).thenReturn(systemStatus);
-    this.mockMvc.perform(get("/status")).andExpect(status().is5xxServerError());
+    mockMvc.perform(get("/status")).andExpect(status().is5xxServerError());
   }
 
   @Test
@@ -53,7 +53,7 @@ class PublicApiControllerTest {
     when(versionConfiguration.getGithub()).thenReturn(github);
     when(versionConfiguration.getBuild()).thenReturn(build);
 
-    this.mockMvc
+    mockMvc
         .perform(get("/version"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.gitTag").value(gitTag))
@@ -64,7 +64,7 @@ class PublicApiControllerTest {
 
   @Test
   void testGetSwagger() throws Exception {
-    this.mockMvc
+    mockMvc
         .perform(get("/swagger-ui.html"))
         .andExpect(status().isOk())
         .andExpect(model().attributeExists("clientId"));
@@ -72,6 +72,6 @@ class PublicApiControllerTest {
 
   @Test
   void testIndex() throws Exception {
-    this.mockMvc.perform(get("/")).andExpect(redirectedUrl("swagger-ui.html"));
+    mockMvc.perform(get("/")).andExpect(redirectedUrl("swagger-ui.html"));
   }
 }


### PR DESCRIPTION
This is an attempt to fix the issue where the catalog service starts up in an error state (`/status` endpoint is returning `503`) and never recovers.

One theory is that one of the status checks is taking too long, causing the status check concurrent task to no longer fire. To fix this, I've changed the concurrent task to use `scheduleWithFixedDelay()` instead of `scheduleAtFixedRate()`, which should guard against the case where a status check takes longer than the thread polling interval.

When doing this, I noticed that the timeout for the database check was using 5000 seconds. This check should be very fast so I'm changing the timeout to 1 second instead.

This change also adds unit test coverage for the database status check, and enables performing all the status checks in parallel.