### PR TITLE
[dc-873][dc-887] upgrade postgresql jre7

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,19 +10,19 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.20.0'
+    implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.25.0'
     implementation 'com.felipefzdz.gradle.shellcheck:shellcheck:1.4.6'
-    implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.3.2'
+    implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.4.1'
     implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.12'
-    implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.4.0'
+    implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.5.0'
     implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.14'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.4'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
-    implementation 'org.sonarqube:org.sonarqube.gradle.plugin:4.3.0.3225'
+    implementation 'org.sonarqube:org.sonarqube.gradle.plugin:4.4.1.3373'
     implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.2.3'
     implementation 'bio.terra:terra-test-runner:0.2.0-SNAPSHOT'
     implementation 'com.gorylenko.gradle-git-properties:gradle-git-properties:2.4.1'
-    implementation 'org.liquibase:liquibase-gradle-plugin:2.2.0'
+    implementation 'org.liquibase:liquibase-gradle-plugin:2.2.1'
     // This is required due to a dependency conflict between jib and srcclr. Removing it will cause jib to fail.
     implementation 'org.apache.commons:commons-compress:1.21'
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.1.4'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:4.3.0.3225'
-    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.2.1'
+    implementation 'org.springframework.boot:spring-boot-gradle-plugin:3.2.3'
     implementation 'bio.terra:terra-test-runner:0.2.0-SNAPSHOT'
     implementation 'com.gorylenko.gradle-git-properties:gradle-git-properties:2.4.1'
     implementation 'org.liquibase:liquibase-gradle-plugin:2.2.0'


### PR DESCRIPTION
This also updates a bunch of other plugin versions. It does not update spotbugs because that wasn't a free update, so I decided it was best to keep the changes as minimal as possible, and update that one more intentionally.