### PR TITLE
DC-839: Move references back to datarepo-client; Upgrade to latest

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.catalog.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.catalog.java-common-conventions.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'bio.terra:terra-common-lib:0.1.9-SNAPSHOT'
     // guava is depended on by terra-common-lib, https://broadworkbench.atlassian.net/browse/DC-798
     implementation 'com.google.guava:guava:31.1-jre'
-    implementation 'bio.terra:datarepo-jakarta-client:1.563.0-SNAPSHOT'
+    implementation 'bio.terra:datarepo-client:2.13.0-SNAPSHOT'
 }
 
 tasks.named('test') {

--- a/common/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
+++ b/common/src/main/java/bio/terra/catalog/datarepo/DatarepoService.java
@@ -72,7 +72,7 @@ public class DatarepoService implements StorageSystemService {
       EnumerateSnapshotModel response =
           datarepoClient
               .snapshotsApi()
-              .enumerateSnapshots(null, MAX_DATASETS, null, null, null, null, null, null);
+              .enumerateSnapshots(null, MAX_DATASETS, null, null, null, null, null, null, null);
       Map<String, List<String>> roleMap = response.getRoleMap();
 
       return response.getItems().stream()

--- a/common/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
+++ b/common/src/test/java/bio/terra/catalog/datarepo/DatarepoServiceTest.java
@@ -73,7 +73,8 @@ class DatarepoServiceTest {
         new EnumerateSnapshotModel()
             .items(List.of(new SnapshotSummaryModel().id(snapshotId).phsId("1234")))
             .roleMap(items);
-    when(snapshotsApi.enumerateSnapshots(any(), any(), any(), any(), any(), any(), any(), any()))
+    when(snapshotsApi.enumerateSnapshots(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(esm);
     var returnedItems = datarepoService.getDatasets();
     assertThat(returnedItems, is(expectedItems));
@@ -99,7 +100,8 @@ class DatarepoServiceTest {
   @Test
   void getSnapshotsException() throws Exception {
     mockSnapshots();
-    when(snapshotsApi.enumerateSnapshots(any(), any(), any(), any(), any(), any(), any(), any()))
+    when(snapshotsApi.enumerateSnapshots(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenThrow(new ApiException());
     assertThrows(DatarepoException.class, () -> datarepoService.getDatasets());
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DC-839
_______
With the https://github.com/DataBiosphere/jade-data-repo/pull/1581 for data repo, we're switching back to only publishing to one Jakarta backed client. This PR moves your references to the jakarta client back to the main data repo client and bumps to the latest version. This is an effort to alleviate any confusion around upgrading past the last supported datarepo-jakarta-client version.