### PR TITLE
DC-1286: switch to new 17 distroless base image

### DIFF
--- a/service/publishing.gradle
+++ b/service/publishing.gradle
@@ -21,7 +21,7 @@ task extractProfilerAgent(dependsOn: downloadProfilerAgent, type: Copy) {
 jib {
     from {
         // see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre
-        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-distroless"
+        image = "us.gcr.io/broad-dsp-gcr-public/base/jre:17-12-distroless"
     }
     extraDirectories {
         paths = [file(jibExtraDirectory)]


### PR DESCRIPTION
A CVE was discovered in the Debian 11 OS which is the OS used by the 17-distroless image. (It's called distroless but it's really a minimal install; there's no way to make a launchable java container without including some OS distro.) The CVE itself is in the Debian OS, not jre 17, but there is no patch for release 11. The latest distroless image uses Debian 12 as its base image, which has been patched.

In theory this should be a completely safe change to make and shoudln't have any effect on the java code run inside the container. So one possible solution would be change the base image (which is a DSP appsec "blessed" image) to use the OS 12 image. Instead the base image tag was changed, so any dependent repo needs to be updated to use the new base image.

One thing that's been brought up is migrating to jre 21. This would also fix the problem, as that base image was already using Debian 12, but changing from jre 17 to 21 could cause other problems and would need more testing to apply.