### PR TITLE
[DT-940] Centralize the GitHub Action Slack configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# Documentation with syntax examples:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in the repo.
+*       @DataBiosphere/dsp-data-team-eng

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -216,7 +216,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          channel: '#dsp-data-exploration'
+          channel: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
           status: failure
           author_name: Build on dev
           fields: job,message

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -107,13 +107,13 @@ jobs:
     if: failure()
 
     steps:
-      - name: "Notify #dsp-data-exploration Slack on failure"
+      - name: "Notify Slack channel on failure"
         uses: broadinstitute/action-slack@v3.15.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           STATUS: failure
         with:
-          channel: '#dsp-data-exploration'
+          channel: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
           status: ${{ env.STATUS }}
           fields: job,ref
           text: >

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          channel: '#dsp-data-exploration'
+          channel: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
           status: failure
           author_name: Publish to dev
           fields: job

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          channel: '#dsp-data-exploration'
+          channel: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
           status: failure
           author_name: Trivy action
           fields: workflow,message


### PR DESCRIPTION
Centralizes the configuration for Slack channels in a single variable, and add a CODEOWNERS file so our team is notified on changes.