### PR TITLE
[DT-1022] Add CSP to the Swagger UI using meta tag

### DIFF
--- a/service/src/main/resources/templates/index.html
+++ b/service/src/main/resources/templates/index.html
@@ -5,6 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';">
   <meta
     name="description"
     content="Data Catalog SwaggerUI"


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1022

### Summary

Similar to https://github.com/DataBiosphere/terra-landing-zone-service/pull/502 and https://github.com/DataBiosphere/terra-workspace-data-service/pull/941 , adds a Content Security Policy to the Swagger UI using a `meta` tag.

The team decided to use this approach instead of the proxy approach since catalog currently has no proxy templating which means that we would either need to modify it for all services or add our own template for catalog, both of which were deemed high risk and low value, especially since catalog is likely to be retired in the near future. Additionally, proxy changes are hard to test, whereas this change was straightforward to test.

### Testing

Tested with a catalog instance locally, tried endpoints and the login, no errors were observed in the console. Next, added a CDN delivered resource, and saw failures relating to that resource in the console.