### PR TITLE
[DT-1122] Implement `zizmor` suggestions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -56,6 +58,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -84,6 +88,7 @@ jobs:
         # Needed by sonar to get the git history for the branch the PR will be merged into.
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -121,6 +126,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -151,6 +158,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -168,8 +177,10 @@ jobs:
       - name: Build image locally with jib
         run: |
           ./gradlew --build-cache :service:jibDockerBuild \
-            --image=${{ steps.image-name.outputs.name }} \
+            --image="${IMAGE_NAME}" \
             -Djib.console=plain
+        env:
+          IMAGE_NAME: ${{ steps.image-name.outputs.name }}
 
       - name: Make sure Postgres is ready and init
         env:
@@ -185,7 +196,9 @@ jobs:
 
       - name: Launch the background process for integration tests
         # 172.17.0.1 is the IP address of the gateway in the default docker bridge network. https://docs.docker.com/network/network-tutorial-standalone/
-        run: docker run -e DATABASE_HOSTNAME=172.17.0.1 -e SPRING_PROFILES_INCLUDE=human-readable-logging -p 8080:8080 -d --name catalog ${{ steps.image-name.outputs.name }}
+        run: docker run -e DATABASE_HOSTNAME=172.17.0.1 -e SPRING_PROFILES_INCLUDE=human-readable-logging -p 8080:8080 -d --name catalog "${IMAGE_NAME}"
+        env:
+          IMAGE_NAME: ${{ steps.image-name.outputs.name }}
 
       - name: Wait for boot run to be ready
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,12 +9,11 @@ on:
         required: true
         options:
           - staging
-          - alpha
           - dev
         default: 'dev'
 
 env:
-  TEST_ENV: ${{ github.event.inputs.environment }}
+  TEST_INPUT: ${{ github.event.inputs.environment }}
   TEST_DEFAULT: dev
 
 jobs:
@@ -23,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -53,7 +54,9 @@ jobs:
       - name: Set default test env
         id: test-env
         run: |
-          echo "test-env=${{ env.TEST_ENV || env.TEST_DEFAULT }}" >> $GITHUB_OUTPUT
+          TEST_ENV=${TEST_INPUT:-$TEST_DEFAULT}
+          echo "test-env=${TEST_ENV}" >> $GITHUB_OUTPUT
+          echo "Running tests in '${TEST_ENV}' environment"
 
   test-runner:
     needs: [ build, test-env ]
@@ -61,6 +64,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Get the helm chart versions for the test env
         run: |
@@ -70,8 +75,10 @@ jobs:
             --create-dirs -o "integration/src/main/resources/rendered/dev.yaml"
           curl -H 'Authorization: token ${{ secrets.BROADBOT_TOKEN }}' \
             -H 'Accept: application/vnd.github.v3.raw' \
-            -L https://api.github.com/repos/broadinstitute/terra-helmfile/contents/environments/live/${{ needs.test-env.outputs.test-env }}.yaml \
-            --create-dirs -o "integration/src/main/resources/rendered/${{ needs.test-env.outputs.test-env }}.yaml"
+            -L https://api.github.com/repos/broadinstitute/terra-helmfile/contents/environments/live/${TEST_ENV}.yaml \
+            --create-dirs -o "integration/src/main/resources/rendered/${TEST_ENV}.yaml"
+        env:
+          TEST_ENV: ${{ needs.test-env.outputs.test-env }}
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -87,7 +94,9 @@ jobs:
 
       - name: Run integration test suite
         run: |
-          ./gradlew --build-cache runTest --args="suites/${{ needs.test-env.outputs.test-env }}/FullIntegration.json build/reports"
+          ./gradlew --build-cache runTest --args="suites/${TEST_ENV}/FullIntegration.json build/reports"
+        env:
+          TEST_ENV: ${{ needs.test-env.outputs.test-env }}
 
       - name: Upload Test Reports for QA
         if: always()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -41,16 +43,22 @@ jobs:
 
       - name: Construct docker image name and tag
         id: image-name
-        run: echo "name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}" >> $GITHUB_OUTPUT
+        run: echo "name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${GIT_TAG}" >> $GITHUB_OUTPUT
+        env:
+          GIT_TAG: ${{ steps.tag.outputs.tag }}
 
       - name: Build image locally with jib
         run: |
           ./gradlew --build-cache :service:jibDockerBuild \
-          --image=${{ steps.image-name.outputs.name }} \
+          --image="$IMAGE_NAME" \
           -Djib.console=plain
+        env:
+          IMAGE_NAME: ${{ steps.image-name.outputs.name }}
 
       - name: Push GCR image
-        run: docker push ${{ steps.image-name.outputs.name }}
+        run: docker push "${IMAGE_NAME}"
+        env:
+          IMAGE_NAME: ${{ steps.image-name.outputs.name }}
 
       - name: Deploy to Terra Dev environment
         uses: broadinstitute/repository-dispatch@master

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,6 +9,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
+          persist-credentials: false
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
         uses: databiosphere/github-actions/actions/bumper@bumper-0.2.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,7 +9,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
-          persist-credentials: false
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
         uses: databiosphere/github-actions/actions/bumper@bumper-0.2.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -25,8 +27,10 @@ jobs:
       - name: Build image locally with jib
         run: |
           ./gradlew --build-cache :service:jibDockerBuild \
-            --image=${{ steps.image-name.outputs.name }} \
+            --image="${IMAGE_NAME}" \
             -Djib.console=plain
+        env:
+          IMAGE_NAME: ${{ steps.image-name.outputs.name }}
 
       - name: Run Trivy vulnerability scanner
         uses: broadinstitute/dsp-appsec-trivy-action@v1

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 repositories {
+    mavenCentral()
     maven {
         url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
     }


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-1122

## Summary

- Do not persist credentials if not needed
- Use shell variable expansion instead of [template expansion](https://woodruffw.github.io/zizmor/audits/#template-injection)
- Include `mavenCentral` in gradle build to fix build issues